### PR TITLE
Update The_Cartridge_Header.md

### DIFF
--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -244,7 +244,7 @@ entry. The GAME WON'T WORK if this checksum is incorrect.
 
 ### 014E-014F - Global Checksum
 
-Contains a 16 bit checksum (upper byte first) across the whole cartridge
+Contains a 16 bit checksum (least significant byte first) across the whole cartridge
 ROM. Produced by adding all bytes of the cartridge (except for the two
 checksum bytes). The Game Boy doesn't verify this checksum.
 


### PR DESCRIPTION
The checksum is stored in little-endian form, which has the least significant byte first. This was incorrect in the originals, but I have checked this on two games by Nintendo with verified good dumps:

* Super Mario Land v1.1 Japan/US/Europe
* Super Mario Land 2 v1.0 USA/Europe