### PR TITLE
Use vuepress-plugin-git-log to embed commit metadata.

### DIFF
--- a/content/About.md
+++ b/content/About.md
@@ -2,3 +2,9 @@ This is a new, experimental version of Pan Docs, mantained in the Markdown forma
 
 To learn more about the history and the mission of the project, check the [README](https://github.com/gbdev/pandocs#history).
 
+This document version was produced from git commit
+<a :href="`https://github.com/gbdev/pandocs/tree/${$page.git.HEAD.hash}`"
+    target="_blank">
+    {{ $page.git.HEAD.shorthash }}<OutboundLink />
+</a>
+({{ $page.git.HEAD.timestamp }})

--- a/render/.vuepress/config.js
+++ b/render/.vuepress/config.js
@@ -2,6 +2,25 @@ module.exports = {
   "title": "Pan Docs",
   // We're serving this on gbdev.github.io/pandocs
   base: "/pandocs/",
+  plugins: [
+    ['git-log', {
+      onlyFirstAndLastCommit: true,
+      extendGitLog: (git) => {
+        const spawn = require("cross-spawn").sync
+
+        const res = spawn("git", ["log", "-1", "--format=%H/%h/%ci", "HEAD"])
+        if (res.stderr.toString().trim()) return
+
+        const [hash, shorthash, timestamp ] = res.stdout.toString().trim().split("/")
+
+        git.HEAD = {
+          hash,
+          shorthash,
+          timestamp,
+        }
+      },
+    }],
+  ],
   themeConfig: {
     navbar: false
     /*

--- a/render/merge.sh
+++ b/render/merge.sh
@@ -1,23 +1,12 @@
-commithash=$(git rev-parse HEAD)
-shortcommithash=$(git rev-parse --short HEAD)
-timestamp=$(git show -s --format=%ci HEAD)
-
 cd ../content
-cp About.md About2.md
-
-echo "This document version was produced from git commit ["$shortcommithash"](https://github.com/gbdev/pandocs/tree/"$commithash") ("$timestamp")." >> About.md
 
 echo "Producing the merged markdown file.."
-
 markdown-pp index.mdpp -o ../render/index.md -e latexrender
-
-echo "Restoring untemplated version of About.md"
-mv About2.md About.md
 
 cd -
 
 echo "Copying single non-templated articles.."
-cp ../content/Timer_Obscure_Behaviour.md . --verbose 
+cp ../content/Timer_Obscure_Behaviour.md . --verbose
 
 echo "Copying image assets.."
 cp ../content/imgs .vuepress/public/ -r --verbose

--- a/render/package.json
+++ b/render/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "dev":"vuepress dev",
+    "dev": "vuepress dev",
     "build": "vuepress build",
     "remove-prism": "sed -i.bak -e \":a\" -e 'N' -e '$!ba' -e \"s/<style src=\\\"prismjs.*css\\\"><\\/style>/ /\" node_modules/@vuepress/theme-default/layouts/Layout.vue",
     "deploy": "vuepress build && npx gh-pages -d .vuepress/dist -b master",
@@ -17,6 +17,7 @@
   "dependencies": {
     "gh-pages": "^2.2.0",
     "typeface-inter": "^3.11.2",
-    "vuepress": "^1.2.0"
+    "vuepress": "^1.2.0",
+    "vuepress-plugin-git-log": "^1.0.1"
   }
 }


### PR DESCRIPTION
This simplifies the workflow (and maybe it can also be the solution for #28: `vuepress-plugin-git-log` injects each page with the [`$page.git.updated` and `$page.git.commits` variables](https://github.com/vuepress/vuepress-plugin-git-log#api)).