### PR TITLE
Minor formatting fixes

### DIFF
--- a/content/Memory_Map.md
+++ b/content/Memory_Map.md
@@ -12,7 +12,7 @@ The Game Boy has a 16bit address bus, that is used to address ROM, RAM and I/O
 | C000        | CFFF      | 4KB Work RAM (WRAM) bank 0                                                                       | |
 | D000        | DFFF      | 4KB Work RAM (WRAM) bank 1\~N                                                                    | Only bank 1 in Non-CGB mode Switchable bank 1\~7 in CGB mode |
 | E000        | FDFF      | Mirror of C000\~DDFF (ECHO RAM)                                                                  | Typically not used|
-| FE00        | FE9F      | Sprite attribute table ([OAM](#vram-sprite-attribute-table-oam)   | |
+| FE00        | FE9F      | Sprite attribute table ([OAM](#vram-sprite-attribute-table-oam))   | |
 | FEA0        | FEFF      | Not Usable                                                                                       | |
 | FF00        | FF7F      | I/O Registers                                                                                    | |
 | FF80        | FFFE      | High RAM (HRAM)                                                                                  | |

--- a/content/Sound_Controller.md
+++ b/content/Sound_Controller.md
@@ -379,7 +379,7 @@ The APU was reworked pretty heavily for the GBA. Instead of mixing being
 done analogically, it's instead done digitally; then, sound is
 converted to an analog signal and an offset is added (see SOUNDBIAS in
 [GBATEK](http://problemkaputt.de/gbatek.htm#gbasoundcontrolregisters)
-for more details.
+for more details).
 
 This means that the APU has no DACs, or if modelling the GBA as a GB,
 they're always on.

--- a/content/Sprite_RAM_Bug.md
+++ b/content/Sprite_RAM_Bug.md
@@ -79,13 +79,13 @@ bitwise expression is `b | (a & c)`.
 
 ## Write During Increase/Decrease
 
-If a register is increased or decreased in the same M cycle of a write,
+If a register is increased or decreased in the same M-cycle of a write,
 this will effectively trigger two writes in a single M-cycle. However,
 this case behaves just like a single write.
 
 ## Read During Increase/Decrease
 
-If a register is increased or decreased in the same M cycle of a write,
+If a register is increased or decreased in the same M-cycle of a write,
 this will effectively trigger both a read **and** a write in a single
 M-cycle, resulting in a more complex corruption pattern:
 


### PR DESCRIPTION
I didn't do a comprehensive check for unmatched parenthesis. 'M-cycle' hyphenation is for consistency with the rest of the document (and the other usage of M-cycle in the very same sentences).