### PR TITLE
Corrections w.r.t. the address of the LCDC register

### DIFF
--- a/content/LCDC.md
+++ b/content/LCDC.md
@@ -1,4 +1,4 @@
-# LCD Control Register
+# FF40 - LCD Control Register
 
 **LCDC** is the main **LCD C**ontrol register. Its bits toggle what
 elements are displayed on the screen, and how.

--- a/content/Video_Display.md
+++ b/content/Video_Display.md
@@ -93,7 +93,7 @@ milliseconds.
 ### INT 48 - LCDC Status Interrupt
 
 There are various reasons for this interrupt to occur as described by
-the STAT register (\$FF40). One very popular reason is to indicate to
+the STAT register (\$FF41). One very popular reason is to indicate to
 the user when the video hardware is about to redraw a given LCD line.
 This can be useful for dynamically controlling the SCX/SCY registers
 ($FF43/$FF42) to perform special video effects.


### PR DESCRIPTION
This PR fixes two mistakes:
 - the description of the LCDC status interrupt was claiming STAT lives at $FF40
 - the address of LCDC wasn't mentioned in the section describing it