### PR TITLE
Make it clear that OPRI is not actually a register that is usable from a normal cartridge game/rom

### DIFF
--- a/content/CGB_Registers.md
+++ b/content/CGB_Registers.md
@@ -94,8 +94,11 @@ does not include an infra-red port.
 This register serves as a flag for which object priority mode to use. While
 the DMG prioritizes objects by x-coordinate, the CGB prioritizes them by
 location in OAM. This flag is set by the CGB bios after checking the game's
-CGB compatibility. Changing this bit outside of the bootrom seems to have no
-effect.
+CGB compatibility. 
+
+::: warning TO BE VERIFIED
+Changing this bit outside of the bootrom seems to have no effect.
+:::
 
 ```
 Bit 0: OBJ Priority Mode (0=OAM Priority, 1=Coordinate Priority) (Read/Write)

--- a/content/CGB_Registers.md
+++ b/content/CGB_Registers.md
@@ -94,7 +94,8 @@ does not include an infra-red port.
 This register serves as a flag for which object priority mode to use. While
 the DMG prioritizes objects by x-coordinate, the CGB prioritizes them by
 location in OAM. This flag is set by the CGB bios after checking the game's
-CGB compatibility.
+CGB compatibility. Changing this bit outside of the bootrom seems to have no
+effect.
 
 ```
 Bit 0: OBJ Priority Mode (0=OAM Priority, 1=Coordinate Priority) (Read/Write)


### PR DESCRIPTION
The current description of OPRI does not make it clear that changing it outside of the boot rom has no effect.

While maybe there will be a way found in the future to effect the mode, as long as we don't know, it's better not to word this so as if this register actually does something.