### PR TITLE
Fix many malformed local links

### DIFF
--- a/content/Gameboy_Printer.md
+++ b/content/Gameboy_Printer.md
@@ -1,7 +1,7 @@
 The Gameboy Printer is a portable thermal printer made by
 [SII](http://www.sii.co.jp) for Nintendo, which a few games used to
 print out bonus artwork, certificates, pictures ([Gameboy
-Camera](Gameboy_Camera "wikilink"))\...
+Camera](#gameboy-camera)).
 
 It can use standard 38mm paper and interfaces with the Gameboy through
 the Link port.

--- a/content/LCDC.md
+++ b/content/LCDC.md
@@ -23,7 +23,7 @@ OAM, etc.
 
 ::: warning
 Stopping LCD operation (Bit 7 from 1 to 0) may be performed
-during [VBlank](VBlank "wikilink") ONLY, disabling the display outside
+during VBlank ONLY, disabling the display outside
 of the V-Blank period may damage the hardware by burning in a black
 horizontal line similar to that which appears when the GB is turned off.
 This appears to be a serious issue, Nintendo is reported to reject any
@@ -47,9 +47,9 @@ one.
 
 ## LCDC.5 - Window Display Enable
 
-This bit controls whether the window shall be displayed or not. (TODO :
+This bit controls whether the window shall be displayed or not. (TODO:
 what happens when toggling this mid-scanline ?) This bit is overridden
-on DMG by [bit 0](#LCDC.0_-_BG.2FWindow_Display.2FPriority "wikilink")
+on DMG by [bit 0](#lcdc-0-bg-window-display-priority)
 if that bit is reset.
 
 Note that on CGB models, setting this bit to 0 then back to 1 mid-frame
@@ -58,7 +58,7 @@ may cause the second write to be ignored. (TODO : test this.)
 ## LCDC.4 - BG & Window Tile Data Select
 
 This bit controls which [addressing
-mode](Video_Display#VRAM_Tile_Data "wikilink") the BG and Window use to
+mode](#vram-tile-data) the BG and Window use to
 pick tiles.
 
 Sprites aren't affected by this, and will always use \$8000 addressing
@@ -95,7 +95,7 @@ LCDC.0 has different meanings depending on Game Boy type and Mode:
 ### Monochrome Gameboy, SGB and CGB in Non-CGB Mode: BG Display
 
 When Bit 0 is cleared, both background and window become blank (white),
-and the [Window Display Bit](#LCDC.5_-_Window_Display_Enable "wikilink")
+and the [Window Display Bit](#lcdc-5-window-display-enable)
 is ignored in that case. Only Sprites may still be displayed (if enabled
 in Bit 1).
 
@@ -123,5 +123,5 @@ the textbox/status bar is "alone" on its scanlines:
 -   Set LCDC.1 to 0 for textbox/status bar scanlines
 
 Usually, these bars are either at the top or bottom of the screen, so
-the bit can be set by the [VBlank handler](VBlank_handler "wikilink")
+the bit can be set by the VBlank handler.
 

--- a/content/MBC6.md
+++ b/content/MBC6.md
@@ -5,7 +5,7 @@ MBC6 (Memory Bank Controller 6) is an unusual MBC that contains two
 separately switchable ROM banks ($4000 and $6000) and RAM banks
 ($A000 and $B000), SRAM and an 8 Mbit Macronix MX29F008TC-14 flash
 memory chip. It is only used in one game, Net de Get: Minigame @ 100,
-which uses the [Mobile Adapter](Mobile_Adapter "wikilink") to connect to
+which uses the Mobile Adapter to connect to
 the web to download minigames onto the local flash. Both ROM banks and
 both RAM banks are views into the same ROM and RAM, but with separately
 adjustable offsets. Since the banked regions are smaller the effective

--- a/content/Memory_Map.md
+++ b/content/Memory_Map.md
@@ -45,7 +45,7 @@ area are required to be specified correctly.
 The areas from 0000-7FFF and A000-BFFF may be used to connect external
 hardware. The first area is typically used to address ROM (read only, of
 course), cartridges with [Memory Bank Controllers
-(MBCs)](Memory_Bank_Controllers "wikilink") are additionally using this
+(MBCs)](#memory-bank-controllers) are additionally using this
 area to output data (write only) to the MBC chip. The second area is
 often used to address external RAM, or to address other external
 hardware (Real Time Clock, etc). External memory is

--- a/content/SGB_Functions.md
+++ b/content/SGB_Functions.md
@@ -354,7 +354,7 @@ color 1-3 (without separate color 0).
 ` F     Not used (00h)`<br>
 
 This is the same RGB5 format as [Game Boy Color palette
-entry](Video_Display#LCD_Color_Palettes_(CGB_only) "wikilink"), though
+entry](#lcd-color-palettes-cgb-only), though
 without the LCD correction. The value transferred as color 0 will be
 applied for all four palettes.
 
@@ -812,7 +812,7 @@ cartridge in a Super Game Boy as a storage server:
 -   The SGB system software does not appear to use NMIs.
 -   JUMP can return to SGB system software via a 16-bit RTS. To do this,
     JML to a location in bank $00 containing byte value $60, such as
-    any of the [stubbed commands](#Stubbed_commands "wikilink").
+    any of the [stubbed commands](#stubbed-commands).
 -   IRQs and COP and BRK instructions are not useful because their
     handlers still point into SGB ROM. Use SEI WAI.
 -   If a program called through JUMP does not intend to return to SGB

--- a/content/Timer_and_Divider_Registers.md
+++ b/content/Timer_and_Divider_Registers.md
@@ -1,3 +1,10 @@
+::: tip NOTE
+The Timer described below is the built-in timer in the gameboy. It has
+nothing to do with the MBC3s battery buffered Real Time Clock - that\'s
+a completely different thing, described in
+[Memory Bank Controllers](#memory-bank-controllers).
+:::
+
 ### FF04 - DIV - Divider Register (R/W)
 
 This register is incremented at rate of 16384Hz (\~16779Hz on SGB).
@@ -38,15 +45,3 @@ Each time when the timer overflows (ie. when TIMA gets bigger than FFh),
 then an interrupt is requested by setting Bit 2 in the IF Register
 (FF0F). When that interrupt is enabled, then the CPU will execute it by
 calling the timer interrupt vector at 0050h.
-
-### Timer Obscure Behaviour
-
-Read this page for a more detailed description of what the registers do:
-[Timer Obscure Behaviour](Timer_Obscure_Behaviour "wikilink")
-
-::: tip NOTE
-The above described Timer is the built-in timer in the gameboy. It has
-nothing to do with the MBC3s battery buffered Real Time Clock - that\'s
-a completely different thing, described in the chapter about Memory
-Banking Controllers.
-:::

--- a/content/Video_Display.md
+++ b/content/Video_Display.md
@@ -272,7 +272,7 @@ darker colors.
 
 Newer CGB games may avoid this effect by changing palette data when
 detecting GBA hardware ([see
-how](CGB_Registers#Detecting_CGB_.28and_GBA.29_functions "wikilink")).
+how](#detecting-cgb-and-gba-functions)).
 Based on measurement of GBC and GBA palettes using the [144p Test
 Suite](https://github.com/pinobatch/240p-test-mini/tree/master/gameboy) ROM, a fairly close approximation is GBA = GBC \* 3/4 + 8h for
 each R,G,B intensity. The result isn't quite perfect, and it may turn
@@ -465,7 +465,7 @@ by both addressing methods)
 
 Sprites always use 8000 addressing, but the BG and Window can use either
 mode, controlled by [LCDC bit
-4](#LCDC.4_-_BG_.26_Window_Tile_Data_Select "wikilink").
+4](#lcdc-4-bg-window-tile-data-select).
 
 Each Tile occupies 16 bytes, where each 2 bytes represent a line:
 
@@ -492,15 +492,15 @@ A more visual explanation can be found
 So, each pixel is having a color number in range from 0-3. The color
 numbers are translated into real colors (or gray shades) depending on
 the current palettes. The palettes are defined through registers
-[BGP](#FF47_-_BGP_-_BG_Palette_Data_.28R.2FW.29_-_Non_CGB_Mode_Only "wikilink"),
-[OBP0](#FF48_-_OBP0_-_Object_Palette_0_Data_.28R.2FW.29_-_Non_CGB_Mode_Only "wikilink")
+[BGP](#ff47-bgp-bg-palette-data-r-w-non-cgb-mode-only),
+[OBP0](#ff48-obp0-object-palette-0-data-r-w-non-cgb-mode-only)
 and
-[OBP1](#FF49_-_OBP1_-_Object_Palette_1_Data_.28R.2FW.29_-_Non_CGB_Mode_Only "wikilink")
+[OBP1](#ff49-obp1-object-palette-1-data-r-w-non-cgb-mode-only)
 (Non CGB Mode), and
-[BCPS/BGPI](#FF68_-_BCPS.2FBGPI_-_CGB_Mode_Only_-_Background_Palette_Index "wikilink"),
-[BCPD/BGPD](#FF69_-_BCPD.2FBGPD_-_CGB_Mode_Only_-_Background_Palette_Data "wikilink"),
+[BCPS/BGPI](#ff68-bcps-bgpi-cgb-mode-only-background-color-palette-specification-or-background-palette-index),
+[BCPD/BGPD](#ff69-bcpd-bgpd-cgb-mode-only-background-color-palette-data-or-background-palette-data),
 [OCPS/OBPI and
-OCPD/OBPD](#FF6A_-_OCPS.2FOBPI_-_CGB_Mode_Only_-_Sprite_Palette_Index.2C_FF6B_-_OCPD.2FOBPD_-_CGB_Mode_Only_-_Sprite_Palette_Data "wikilink")
+OCPD/OBPD](#ff6a-ocps-obpi-object-color-palette-specification-or-sprite-palette-index-ff6b-ocpd-obpd-object-color-palette-data-or-sprite-palette-data-both-cgb-mode-only)
 (CGB Mode).
 
 
@@ -517,7 +517,7 @@ tiles to be displayed. It is organized as 32 rows of 32 bytes each. Each
 byte contains a number of a tile to be displayed.
 
 Tile patterns are taken from the Tile Data Table using either of the two
-addressing modes (described [above](#VRAM_Tile_Data "wikilink")), which
+addressing modes (described [above](#vram-tile-data)), which
 can be selected via LCDC register.
 
 As one background tile has a size of 8x8 pixels, the BG maps may hold a
@@ -646,7 +646,7 @@ if sprite size is set to 8x8). Just setting the X coordinate to X = 0 or
 X \>= 168 (160 + 8) on a sprite will hide it, but it will still affect
 other sprites sharing the same lines.
 
-If using [BGB](BGB "wikilink"), in the VRAM viewer - OAM tab, hover your
+If using BGB, in the VRAM viewer - OAM tab, hover your
 mouse over the small screen to highlight the sprites on a line. Sprites
 hidden due to the limitation will be highlighted in red.
 
@@ -721,7 +721,7 @@ If you're not using LCD interrupts, another way to synchronize to the
 start of mode 0 is to use `halt` with IME turned off (`di`). This allows
 use of the entire mode 0 on one line and mode 2 on the following line,
 which sum to 165 to 288 dots. For comparison, at single speed (4 dots
-per machine cycle), a [copy from stack](Popslide "wikilink") that takes
+per machine cycle), a copy from stack that takes
 9 cycles per 2 bytes can push 8 bytes (half a tile) in 144 dots, which
 fits within the worst case timing for mode 0+2.
 

--- a/content/index.mdpp
+++ b/content/index.mdpp
@@ -127,7 +127,7 @@ title: 'Pan Docs'
 As the gameboys 16 bit address bus offers only limited space for ROM and RAM addressing, many games are using Memory Bank Controllers (MBCs) to expand the available address space by bank switching. These MBC chips are located in the game cartridge (ie. not in the gameboy itself).
 
 In each cartridge, the required (or preferred) MBC type should be specified in the byte at 0147h of the ROM, as described in the [the
-cartridge header](#the-cartrdige-header). Several different MBC types are available: 
+cartridge header](#the-cartridge-header). Several different MBC types are available: 
 
 # No MBC
 

--- a/content/othermbc.md
+++ b/content/othermbc.md
@@ -19,7 +19,7 @@ PinoBatch learned the game selection protocol for EMS flash carts from
 beware, who in turn learned it from nitro2k01. Take this with a grain of
 salt, as it hasn't been verified on the authentic EMS hardware.
 
-A [header](The_Cartridge_Header "wikilink") matching any of the
+A [header](#the-cartridge-header) matching any of the
 following is detected as EMS mapper:
 
 -   Header name is "EMSMENU", NUL-padded


### PR DESCRIPTION
In the process, I removed a few links specific to the original wiki:

BGB, which originally linked to https://gbdev.gg8.se/wiki/articles/BGB

Mobile Adapter, Popslide, VBlank, and VBlank handler, which were all red links on the wiki.

I opted to retain gameboy-camera but transform it to a proper local link, even though it isn't currently rendered, because Gameboy_Camera.md exists and could be added to the document later.

The links in Gameboy_Camera.md and Pan_Docs.md were left untouched because they are not currently rendered.