### PR TITLE
Fix URL hash pointers in Chromium (and other?) browsers

### DIFF
--- a/render/.vuepress/config.js
+++ b/render/.vuepress/config.js
@@ -1,7 +1,24 @@
 module.exports = {
-  "title": "Pan Docs",
+  title: "Pan Docs",
   // We're serving this on gbdev.github.io/pandocs
   base: "/pandocs/",
+  head: [
+  // https://github.com/gbdev/pandocs/issues/38
+    [
+      "script",
+      {},
+      `
+    window.addEventListener('load', function () {
+        var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+        if (window.location.hash && isChrome) {
+          var hash = window.location.hash;
+          window.location.hash = "";
+          window.location.hash = hash;
+        }
+    });
+  `
+    ]
+  ],
   themeConfig: {
     navbar: false
     /*
@@ -11,4 +28,4 @@ module.exports = {
     ]
     */
   }
-}
+};


### PR DESCRIPTION
fixes #38 

I think the actual issue here was content not being loaded at the time that the browser was attempting to follow the hash.
Fix is to wait for `window.load`, then reset the hash

![scrollo](https://user-images.githubusercontent.com/6645121/96008398-85f93e80-0e0d-11eb-9337-b0c399de6f3a.gif)
