### PR TITLE
Replace ' with " and fix GB Printer Table

### DIFF
--- a/content/CGB_Registers.md
+++ b/content/CGB_Registers.md
@@ -10,7 +10,7 @@ When using any CGB registers (including those in the Video/Link
 chapters), you must first unlock CGB features by changing byte 0143h in
 the cartridge header. Typically use a value of 80h for games which
 support both CGB and monochrome gameboys, and C0h for games which work
-on CGBs only. Otherwise, the CGB will operate in monochrome 'Non CGB'
+on CGBs only. Otherwise, the CGB will operate in monochrome "Non CGB"
 compatibility mode.
 
 # Detecting CGB (and GBA) functions
@@ -20,7 +20,7 @@ directly after startup. A value of 11h indicates CGB (or GBA) hardware,
 if so, CGB functions can be used (if unlocked, see above). When A=11h,
 you may also examine Bit 0 of the CPUs B-Register to separate between
 CGB (bit cleared) and GBA (bit set), by that detection it is possible to
-use 'repaired' color palette data matching for GBA displays.
+use "repaired" color palette data matching for GBA displays.
 
 # Documented registers
 
@@ -35,7 +35,7 @@ This register is used to prepare the Game Boy to switch between CGB
 Double Speed Mode and Normal Speed Mode. The actual speed switch is
 performed by executing a STOP command after Bit 0 has been set. After
 that Bit 0 will be cleared automatically, and the Game Boy will operate
-at the 'other' speed. The recommended speed switching procedure in
+at the "other" speed. The recommended speed switching procedure in
 pseudo code would be:
 
 ```

--- a/content/Gameboy_Printer.md
+++ b/content/Gameboy_Printer.md
@@ -21,14 +21,14 @@ The packets all follow this format:
 
 |                       | Size (bytes) | GB -> Printer | Printer -> GB |
 |-----------------------|--------------|---------------|---------------|
-| Magic bytes           | 2            | $88           | 0x00          |
-| Command               | 1            | $33           | 0x00          |
-|  Compression flag     | 1            | See below     | 0x00          |
-| Length of data        | 2            | 0/1           | 0x00          |
-| Command-specific data | Variable     | LSB           | 0x00          |
-| Checksum              | 2            | MSB           | 0x00          |
-| Alive indicator       | 1            | See below     | 0x00          |
-| Status                | 1            | LSB           | 0x00          |
+| Magic bytes           | 2            | $88, $33      | 0x00          |
+| Command               | 1            | See below     | 0x00          |
+|  Compression flag     | 1            | 0/1           | 0x00          |
+| Length of data        | 2            | LSB, MSB      | 0x00          |
+| Command-specific data | Variable     | See below     | 0x00          |
+| Checksum              | 2            | LSB, MSB      | 0x00          |
+| Alive indicator       | 1            |               | 0x00          |
+| Status                | 1            | See below     | 0x00          |
 
 The checksum is simply a sum of every byte sent except the magic bytes
 and obviously, the checksum itself.

--- a/content/Interrupts.md
+++ b/content/Interrupts.md
@@ -53,7 +53,7 @@ becomes set when the LCD controller enters into the V-Blank period.
 Any set bits in the IF register are only **requesting** an interrupt to be
 executed. The actual **execution** happens only if both the IME flag, and
 the corresponding bit in the IE register are set, otherwise the
-interrupt 'waits' until both IME and IE allow its execution.
+interrupt "waits" until both IME and IE allow its execution.
 
 ### Interrupt Execution
 

--- a/content/SGB_Functions.md
+++ b/content/SGB_Functions.md
@@ -107,7 +107,7 @@ must be set in order to unlock SGB functions:
 ` 14Bh - Old Licensee Code - Must be set 33h for SGB games`<br>
 
 When these entries aren't set, the game will still work just like all
-'monochrome' Game Boy games, but it cannot access any of the special
+"monochrome" Game Boy games, but it cannot access any of the special
 SGB functions.
 
 ### Detecting SGB hardware
@@ -182,7 +182,7 @@ packets is:
 ` 15 BYTES Parameter Data`<br>
 `  1 BIT   Stop Bit (0)`<br>
 
-The above 'Length' indicates the total number of packets (1-7,
+The above "Length" indicates the total number of packets (1-7,
 including the first packet) which will be sent, ie. if more than 15
 parameter bytes are used, then further packet(s) will follow, as such:
 
@@ -231,7 +231,7 @@ multiple chunks.
 
 ### Avoiding Screen Garbage
 
-The display will contain 'garbage' during the transfer, this
+The display will contain "garbage" during the transfer, this
 dirt-effect can be avoided by freezing the screen (in the state which
 has been displayed before the transfer) by using the MASK_EN command.
 Of course, this works only when actually executing the game on a SGB
@@ -398,8 +398,8 @@ initialized by ATTR_TRN.
 Used to initialize SGB system color palettes in SNES RAM. System color
 palette memory contains 512 pre-defined palettes, these palettes do not
 directly affect the display, however, the PAL_SET command may be later
-used to transfer four of these 'logical' palettes to actual visible
-'physical' SGB palettes. Also, the OBJ_TRN function will use groups
+used to transfer four of these "logical" palettes to actual visible
+"physical" SGB palettes. Also, the OBJ_TRN function will use groups
 of 4 System Color Palettes (4\*4 colors) for SNES OBJ palettes (16
 colors).
 

--- a/content/Sound_Controller.md
+++ b/content/Sound_Controller.md
@@ -196,8 +196,8 @@ currently reading. On GBA, the write will simply be ignored.
 
 This channel is used to output white noise. This is done by randomly
 switching the amplitude between high and low at a given frequency.
-Depending on the frequency the noise will appear 'harder' or
-'softer'.
+Depending on the frequency the noise will appear "harder" or
+"softer".
 
 It is also possible to influence the function of the random generator,
 so the that the output becomes more regular, resulting in a limited
@@ -226,7 +226,7 @@ Length of 1 step = n\*(1/64) seconds
 ### FF22 - NR43 - Channel 4 Polynomial Counter (R/W)
 
 The amplitude is randomly switched between high and low at the given
-frequency. A higher frequency will make the noise to appear 'softer'.
+frequency. A higher frequency will make the noise to appear "softer".
 When Bit 3 is set, the output will become more regular, and some
 frequencies will sound more like Tone than Noise.
 

--- a/content/Video_Display.md
+++ b/content/Video_Display.md
@@ -396,7 +396,7 @@ The H-Blank DMA transfers 10h bytes of
 data during each H-Blank, ie. at LY=0-143, no data is transferred during
 V-Blank (LY=144-153), but the transfer will then continue at LY=00. The
 execution of the program is halted during the separate transfers, but
-the program execution continues during the 'spaces' between each data
+the program execution continues during the "spaces" between each data
 block. Note that the program should not change the Destination VRAM bank
 (FF4F), or the Source ROM/RAM bank (in case data is transferred from
 bankable memory) until the transfer has completed! (The transfer should
@@ -430,7 +430,7 @@ manually terminating a H-Blank Transfer.
 
 In both Normal Speed and Double Speed Mode it takes about 8 μs to
 transfer a block of 10h bytes. That are 8 tstates in Normal Speed Mode,
-and 16 'fast' tstates in Double Speed Mode. Older MBC controllers
+and 16 "fast" tstates in Double Speed Mode. Older MBC controllers
 (like MBC1-4) and slower ROMs are not guaranteed to support General
 Purpose or H-Blank DMA, that's because there are always 2 bytes
 transferred per microsecond (even if the itself program runs it Normal

--- a/content/index.mdpp
+++ b/content/index.mdpp
@@ -1,5 +1,5 @@
 ---
-title: 'Pan Docs'
+title: "Pan Docs"
 ---
 
 <div class="pantitle"> Pan Docs</div>


### PR DESCRIPTION
Replaced instances of single quotes with double quotes (issue #9 ). 
Also fixed the GB Printer table (issue #35 ). I'm pretty sure I've formatted the table correctly now according to the issue. I added "See below" for the Status since it goes more in-depth below, which wasn't mentioned in the issue.