### PR TITLE
Fix broken discord link and readme typos

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@ Everything is in plain Markdown and easily editable by anyone with a GitHub acco
 
 ## Contributing 
 
-[This](https://github.com/gbdev/awesome-gbdev/issues/153) is the RFC proposing the change. You're welcome to discuss the development of this project on the [gbdev Discord chat](https://discord.gg/tKGMPNr) or on IRC (EFNET `#gbdev`, `gbdev2`).
+[This](https://github.com/gbdev/awesome-gbdev/issues/153) is the RFC proposing the change. You're welcome to discuss the development of this project in our various community channels found [here](https://gbdev.io/chat.html).
 
 Contributing is really easy, fork this repo and edit the files in the **content** directory. Then, you can send your PR.
 

--- a/README.MD
+++ b/README.MD
@@ -7,7 +7,7 @@
 
 ## History
 
-Pan Docs - also known as `GAMEBOY.TXT` or `GBSPEC.TXT` - is an old document dating back to early 1995 originally written by *Pan of Anthrox*. It has been one of most important reference for Game Boy hackers, emulators and homebrew developers during the last 25 years.
+Pan Docs - also known as `GAMEBOY.TXT` or `GBSPEC.TXT` - is an old document dating back to early 1995 originally written by *Pan of Anthrox*. It has been one of the most important references for Game Boy hackers, emulators and homebrew developers during the last 25 years.
 
 <p align="center">
 <img src="historical/1995-Jan-28-ATX-GBI/ADDRESS1.png">
@@ -15,17 +15,17 @@ Pan Docs - also known as `GAMEBOY.TXT` or `GBSPEC.TXT` - is an old document dati
   <i>ADDRESS1.PCX, one of the diagrams attached to the first version, released January 28th, 1995</i>
 </p>
 
-After its release (1995-2008), it received a number of revisions, corrections and updates, mantaining its **TXT format**. This [folder](historical/) provides an historical archive of those versions.
+After its release (1995-2008), it received a number of revisions, corrections and updates, maintaining its **TXT format**. This [folder](historical/) provides an historical archive of those versions.
 
-In 2008, a **wikified** version (using Martin Korth's 2001 revision as baseline) has been published. The document has been split in different articles and it continued being mantained and updated in that form.
+In 2008, a **wikified** version (using Martin Korth's 2001 revision as baseline) has been published. The document has been split in different articles and it continued being maintained and updated in that form.
 
-In 2020, we want to make this repository the new home of this resource, where it can receive new public discussions and contributions, mantain its legacy and historical relevance, while making use of recent tools to be visualized and distributed.
+In 2020, we want to make this repository the new home of this resource, where it can receive new public discussions and contributions, maintain its legacy and historical relevance, while making use of recent tools to be visualized and distributed.
 
 Everything is in plain Markdown and easily editable by anyone with a GitHub account by clicking the "Edit" button on the web UI. We accept contributions, patches, suggestions and feedback via email, too (`pandocs (at) gbdev.io`).
 
 ## Contributing 
 
-[This](https://github.com/gbdev/awesome-gbdev/issues/153) is the RFC proposing the change. You're welcome to discuss the development of this project on the [gbdev Discord chat](https://discord.gg/9wBRWWT) or on IRC (EFNET `#gbdev`, `gbdev2`).
+[This](https://github.com/gbdev/awesome-gbdev/issues/153) is the RFC proposing the change. You're welcome to discuss the development of this project on the [gbdev Discord chat](https://discord.gg/tKGMPNr) or on IRC (EFNET `#gbdev`, `gbdev2`).
 
 Contributing is really easy, fork this repo and edit the files in the **content** directory. Then, you can send your PR.
 

--- a/README.MD
+++ b/README.MD
@@ -15,9 +15,9 @@ Pan Docs - also known as `GAMEBOY.TXT` or `GBSPEC.TXT` - is an old document dati
   <i>ADDRESS1.PCX, one of the diagrams attached to the first version, released January 28th, 1995</i>
 </p>
 
-After its release (1995-2008), it received a number of revisions, corrections and updates, maintaining its **TXT format**. This [folder](historical/) provides an historical archive of those versions.
+After its release (1995-2008), it received a number of revisions, corrections and updates, maintaining its **TXT format**. This [folder](historical/) provides a historical archive of those versions.
 
-In 2008, a **wikified** version (using Martin Korth's 2001 revision as baseline) has been published. The document has been split in different articles and it continued being maintained and updated in that form.
+In 2008, a **wikified** version (using Martin Korth's 2001 revision as a baseline) has been published. The document was split into different articles and it continued being maintained and updated in that form.
 
 In 2020, we want to make this repository the new home of this resource, where it can receive new public discussions and contributions, maintain its legacy and historical relevance, while making use of recent tools to be visualized and distributed.
 


### PR DESCRIPTION
- Fix broken Discord link from [old link](https://discord.gg/9wBRWWT) to [new link](https://discord.gg/tKGMPNr) taken from https://gbdev.io/chat.html
- Fix minor typos