### PR TITLE
Document address wrapping behaviour of MBC2 RAM, and note questionable source of $52-$54 ROM size tags

### DIFF
--- a/content/MBC2.md
+++ b/content/MBC2.md
@@ -16,15 +16,22 @@ The MBC2 doesn't support external RAM, instead it includes 512x4 bits
 of built-in RAM (in the MBC2 chip itself). It still requires an external
 battery to save data during power-off though. As the data consists of
 4bit values, only the lower 4 bits of the "bytes" in this memory area
-are used.
+are used. The upper 4 bits of each byte are undefined and should not be
+relied upon.
+
+### A200-BFFF - 15 "echoes" of A000-A1FF
+
+Only the bottom 9 bits of the address are used to index into the internal
+RAM, so RAM access repeats.
 
 ## Control Registers
 
 ### 0000-3FFF - RAM Enable and ROM Bank Number (Write Only)
 
 This address range is responsible for both enabling/disabling the RAM
-and for controlling the ROM bank number. Bit 8 of the address determines
-whether to control the RAM-enable flag or the ROM bank number.
+and for controlling the ROM bank number. Bit 8 of the address (the least
+significant bit of the upper address byte) determines whether to control
+the RAM enable flag or the ROM bank number.
 
 #### When Bit 8 is Clear
 

--- a/content/MBC2.md
+++ b/content/MBC2.md
@@ -22,7 +22,9 @@ relied upon.
 ### A200-BFFF - 15 "echoes" of A000-A1FF
 
 Only the bottom 9 bits of the address are used to index into the internal
-RAM, so RAM access repeats.
+RAM, so RAM access repeats. As with the A000-A1FF region, only the lower
+4 bits of the "bytes" are used, and the upper 4 bits of each byte are
+undefined and should not be relied upon.
 
 ## Control Registers
 

--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -192,7 +192,9 @@ Specifies the ROM Size of the cartridge. Typically calculated as "N such that 32
 | $53 | 1.2 MByte | 80 *
 | $54 | 1.5 MByte | 96 *
 
-\* Only listed in unofficial docs
+\* Only listed in unofficial docs. No cartridges or ROM files using these sizes are known.
+As the other ROM sizes are all powers of 2, these are likely inaccurate. The source for these
+values is unknown.
 
 ### 0149 - RAM Size
 
@@ -200,15 +202,23 @@ Specifies the size of the external RAM in the cartridge (if any).
 
 | Code | Size   | Comment
 |------|--------|---------
-| $00  | 0      | No RAM
-| $01  | -      | Unused (but unofficial docs list it as 2 KB)
+| $00  | 0      | No RAM *
+| $01  | -      | Unused **
 | $02  | 8 KB   | 1 bank
 | $03  | 32 KB  | 4 banks of 8 KB each
 | $04  | 128 KB | 16 banks of 8 KB each
 | $05  | 64 KB  | 8 banks of 8 KB each
 
-When using a MBC2 chip, $00 must be specified in this entry, even though
+\* When using a MBC2 chip, $00 must be specified as the RAM Size, even though
 the MBC2 includes a built-in RAM of 512 x 4 bits.
+
+\** Listed in various unofficial docs as 2KB. However, a 2KB RAM chip was never used in a cartridge.
+The source for this value is unknown.
+
+Various "PD" ROMs ("Public Domain" homebrew ROMs generally tagged "(PD)"
+in the filename) are known to use the $01 RAM Size tag, but this is believed
+to have been a mistake with early homebrew tools and the PD ROMs often don't use
+cartridge RAM at all.
 
 ### 014A - Destination Code
 


### PR DESCRIPTION
Also note that 2KB RAM size tag is erroneously used by a lot of "PD" ROMs (no cart was ever made with this size).