### PR TITLE
Note which options are not used by licensed games

### DIFF
--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -170,7 +170,7 @@ cartridge, and if further external hardware exists in the cartridge.
 |`$FE`|  HuC3|
 |`$FF`|  HuC1+RAM+BATTERY|
 
-*) No licensed game makes use of this option. Exact behaviour is unknown.
+*) No licensed cartridge makes use of this option. Exact behaviour is unknown.
 
 ### 0148 - ROM Size
 

--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -170,7 +170,7 @@ cartridge, and if further external hardware exists in the cartridge.
 |`$FE`|  HuC3|
 |`$FF`|  HuC1+RAM+BATTERY|
 
-*) No licenced game makes use of this option. Exact behavour is unknown.
+*) No licensed game makes use of this option. Exact behaviour is unknown.
 
 ### 0148 - ROM Size
 

--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -147,8 +147,8 @@ cartridge, and if further external hardware exists in the cartridge.
 | $03 | MBC1+RAM+BATTERY
 | $05 | MBC2
 | $06 | MBC2+BATTERY
-| $08 | ROM+RAM (*)
-| $09 | ROM+RAM+BATTERY (*)
+| $08 | ROM+RAM *
+| $09 | ROM+RAM+BATTERY *
 | $0B | MMM01
 | $0C | MMM01+RAM
 | $0D | MMM01+RAM+BATTERY
@@ -170,7 +170,7 @@ cartridge, and if further external hardware exists in the cartridge.
 | $FE | HuC3
 | $FF | HuC1+RAM+BATTERY
 
-*) No licensed cartridge makes use of this option. Exact behaviour is unknown.
+\* No licensed cartridge makes use of this option. Exact behaviour is unknown.
 
 ### 0148 - ROM Size
 
@@ -188,11 +188,11 @@ Specifies the ROM Size of the cartridge. Typically calculated as "N such that 32
 | $06 |   2 MByte | 128
 | $07 |   4 MByte | 256
 | $08 |   8 MByte | 512
-| $52 | 1.1 MByte | 72 *)
-| $53 | 1.2 MByte | 80 *)
-| $54 | 1.5 MByte | 96 *)
+| $52 | 1.1 MByte | 72 *
+| $53 | 1.2 MByte | 80 *
+| $54 | 1.5 MByte | 96 *
 
-*) Only listed in unofficial docs
+\* Only listed in unofficial docs
 
 ### 0149 - RAM Size
 

--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -209,7 +209,7 @@ Specifies the size of the external RAM in the cartridge (if any).
 When using a MBC2 chip $00 must be specified in this entry, even though
 the MBC2 includes a built-in RAM of 512 x 4 bits.
 
-*) No licenced game makes use of this option. Exact behavour is unknown.
+*) No licensed cartridge makes use of this option. Exact behaviour is unknown.
 
 ### 014A - Destination Code
 

--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -147,8 +147,8 @@ cartridge, and if further external hardware exists in the cartridge.
 |`$03`|  MBC1+RAM+BATTERY|
 |`$05`|  MBC2|
 |`$06`|  MBC2+BATTERY|
-|`$08`|  ROM+RAM|
-|`$09`|  ROM+RAM+BATTERY |
+|`$08`|  ROM+RAM (*)|
+|`$09`|  ROM+RAM+BATTERY (*)|
 |`$0B`|  MMM01|
 |`$0C`|  MMM01+RAM|
 |`$0D`|  MMM01+RAM+BATTERY|
@@ -170,6 +170,7 @@ cartridge, and if further external hardware exists in the cartridge.
 |`$FE`|  HuC3|
 |`$FF`|  HuC1+RAM+BATTERY|
 
+*) No licenced game makes use of this option. Exact behavour is unknown.
 
 ### 0148 - ROM Size
 
@@ -198,7 +199,7 @@ Specifies the size of the external RAM in the cartridge (if any).
 
 ```
  $00 - None
- $01 - 2 KBytes
+ $01 - 2 KBytes (*)
  $02 - 8 KBytes
  $03 - 32 KBytes (4 banks of 8KBytes each)
  $04 - 128 KBytes (16 banks of 8KBytes each)
@@ -207,6 +208,8 @@ Specifies the size of the external RAM in the cartridge (if any).
 
 When using a MBC2 chip $00 must be specified in this entry, even though
 the MBC2 includes a built-in RAM of 512 x 4 bits.
+
+*) No licenced game makes use of this option. Exact behavour is unknown.
 
 ### 014A - Destination Code
 


### PR DESCRIPTION
So both ROM developers know that they shouldn't use those options, and Emulator developers know that there isn't a "correct" way to implement these options.