### PR TITLE
Use table instead of code blocks whenever possible

### DIFF
--- a/content/CPU_Instruction_Set.md
+++ b/content/CPU_Instruction_Set.md
@@ -5,142 +5,145 @@ mode), called "T-states".  Because all Game Boy timings are divisible
 by 4, many people specify timings and clock frequency divided by 4,
 called "M-cycles".
 
-### GMB 8-bit Load Commands
+### 8-bit Load instructions
 
-```
- ld   r,r         xx         4 ---- r=r
- ld   r,n         xx nn      8 ---- r=n
- ld   r,(HL)      xx         8 ---- r=(HL)
- ld   (HL),r      7x         8 ---- (HL)=r
- ld   (HL),n      36 nn     12 ---- (HL)=n
- ld   A,(BC)      0A         8 ---- A=(BC)
- ld   A,(DE)      1A         8 ---- A=(DE)
- ld   A,(nn)      FA        16 ---- A=(nn)
- ld   (BC),A      02         8 ---- (BC)=A
- ld   (DE),A      12         8 ---- (DE)=A
- ld   (nn),A      EA        16 ---- (nn)=A
- ld   A,(FF00+n)  F0 nn     12 ---- read from io-port n (memory FF00+n)
- ld   (FF00+n),A  E0 nn     12 ---- write to io-port n (memory FF00+n)
- ld   A,(FF00+C)  F2         8 ---- read from io-port C (memory FF00+C)
- ld   (FF00+C),A  E2         8 ---- write to io-port C (memory FF00+C)
- ldi  (HL),A      22         8 ---- (HL)=A, HL=HL+1
- ldi  A,(HL)      2A         8 ---- A=(HL), HL=HL+1
- ldd  (HL),A      32         8 ---- (HL)=A, HL=HL-1
- ldd  A,(HL)      3A         8 ---- A=(HL), HL=HL-1
-```
-### GMB 16-bit Load Commands
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ ld   r,r        | xx       |    4   | ----  | r=r
+ ld   r,n        | xx nn    |    8   | ----  | r=n
+ ld   r,(HL)     | xx       |    8   | ----  | r=(HL)
+ ld   (HL),r     | 7x       |    8   | ----  | (HL)=r
+ ld   (HL),n     | 36 nn    |   12   | ----  | (HL)=n
+ ld   A,(BC)     | 0A       |    8   | ----  | A=(BC)
+ ld   A,(DE)     | 1A       |    8   | ----  | A=(DE)
+ ld   A,(nn)     | FA       |   16   | ----  | A=(nn)
+ ld   (BC),A     | 02       |    8   | ----  | (BC)=A
+ ld   (DE),A     | 12       |    8   | ----  | (DE)=A
+ ld   (nn),A     | EA       |   16   | ----  | (nn)=A
+ ld   A,(FF00+n) | F0 nn    |   12   | ----  | read from io-port n (memory FF00+n)
+ ld   (FF00+n),A | E0 nn    |   12   | ----  | write to io-port n (memory FF00+n)
+ ld   A,(FF00+C) | F2       |    8   | ----  | read from io-port C (memory FF00+C)
+ ld   (FF00+C),A | E2       |    8   | ----  | write to io-port C (memory FF00+C)
+ ldi  (HL),A     | 22       |    8   | ----  | (HL)=A, HL=HL+1
+ ldi  A,(HL)     | 2A       |    8   | ----  | A=(HL), HL=HL+1
+ ldd  (HL),A     | 32       |    8   | ----  | (HL)=A, HL=HL-1
+ ldd  A,(HL)     | 3A       |    8   | ----  | A=(HL), HL=HL-1
 
-```
- ld   rr,nn       x1 nn nn  12 ---- rr=nn (rr may be BC,DE,HL or SP)
- ld   (nn),SP     08 nn nn  20 ---- (nn)=SP
- ld   SP,HL       F9         8 ---- SP=HL
- push rr          x5        16 ---- SP=SP-2  (SP)=rr   (rr may be BC,DE,HL,AF)
- pop  rr          x1        12 (AF) rr=(SP)  SP=SP+2   (rr may be BC,DE,HL,AF)
-```
-### GMB 8-bit Arithmetic/logical Commands
+### 16-bit Load instructions
 
-```
- add  A,r         8x         4 z0hc A=A+r
- add  A,n         C6 nn      8 z0hc A=A+n
- add  A,(HL)      86         8 z0hc A=A+(HL)
- adc  A,r         8x         4 z0hc A=A+r+cy
- adc  A,n         CE nn      8 z0hc A=A+n+cy
- adc  A,(HL)      8E         8 z0hc A=A+(HL)+cy
- sub  r           9x         4 z1hc A=A-r
- sub  n           D6 nn      8 z1hc A=A-n
- sub  (HL)        96         8 z1hc A=A-(HL)
- sbc  A,r         9x         4 z1hc A=A-r-cy
- sbc  A,n         DE nn      8 z1hc A=A-n-cy
- sbc  A,(HL)      9E         8 z1hc A=A-(HL)-cy
- and  r           Ax         4 z010 A=A & r
- and  n           E6 nn      8 z010 A=A & n
- and  (HL)        A6         8 z010 A=A & (HL)
- xor  r           Ax         4 z000 A=A xor r
- xor  n           EE nn      8 z000 A=A xor n
- xor  (HL)        AE         8 z000 A=A xor (HL)
- or   r           Bx         4 z000 A=A | r
- or   n           F6 nn      8 z000 A=A | n
- or   (HL)        B6         8 z000 A=A | (HL)
- cp   r           Bx         4 z1hc compare A-r
- cp   n           FE nn      8 z1hc compare A-n
- cp   (HL)        BE         8 z1hc compare A-(HL)
- inc  r           xx         4 z0h- r=r+1
- inc  (HL)        34        12 z0h- (HL)=(HL)+1
- dec  r           xx         4 z1h- r=r-1
- dec  (HL)        35        12 z1h- (HL)=(HL)-1
- daa              27         4 z-0x decimal adjust akku
- cpl              2F         4 -11- A = A xor FF
-```
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ ld   rr,nn      | x1 nn nn |   12   | ----  | rr=nn (rr may be BC,DE,HL or SP)
+ ld   (nn),SP    | 08 nn nn |   20   | ----  | (nn)=SP
+ ld   SP,HL      | F9       |    8   | ----  | SP=HL
+ push rr         | x5       |   16   | ----  | SP=SP-2  (SP)=rr ; rr may be BC,DE,HL,AF
+ pop  rr         | x1       |   12   | (AF)  | rr=(SP)  SP=SP+2 ; rr may be BC,DE,HL,AF
 
-### GMB 16-bit Arithmetic/logical Commands
+### 8-bit Arithmetic/logical instructions
 
-```
- add  HL,rr     x9           8 -0hc HL = HL+rr     ;rr may be BC,DE,HL,SP
- inc  rr        x3           8 ---- rr = rr+1      ;rr may be BC,DE,HL,SP
- dec  rr        xB           8 ---- rr = rr-1      ;rr may be BC,DE,HL,SP
- add  SP,dd     E8          16 00hc SP = SP +/- dd ;dd is 8-bit signed number
- ld   HL,SP+dd  F8          12 00hc HL = SP +/- dd ;dd is 8-bit signed number
-```
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ add  A,r        | 8x       |    4   | z0hc  | A=A+r
+ add  A,n        | C6 nn    |    8   | z0hc  | A=A+n
+ add  A,(HL)     | 86       |    8   | z0hc  | A=A+(HL)
+ adc  A,r        | 8x       |    4   | z0hc  | A=A+r+cy
+ adc  A,n        | CE nn    |    8   | z0hc  | A=A+n+cy
+ adc  A,(HL)     | 8E       |    8   | z0hc  | A=A+(HL)+cy
+ sub  r          | 9x       |    4   | z1hc  | A=A-r
+ sub  n          | D6 nn    |    8   | z1hc  | A=A-n
+ sub  (HL)       | 96       |    8   | z1hc  | A=A-(HL)
+ sbc  A,r        | 9x       |    4   | z1hc  | A=A-r-cy
+ sbc  A,n        | DE nn    |    8   | z1hc  | A=A-n-cy
+ sbc  A,(HL)     | 9E       |    8   | z1hc  | A=A-(HL)-cy
+ and  r          | Ax       |    4   | z010  | A=A & r
+ and  n          | E6 nn    |    8   | z010  | A=A & n
+ and  (HL)       | A6       |    8   | z010  | A=A & (HL)
+ xor  r          | Ax       |    4   | z000  | A=A xor r
+ xor  n          | EE nn    |    8   | z000  | A=A xor n
+ xor  (HL)       | AE       |    8   | z000  | A=A xor (HL)
+ or   r          | Bx       |    4   | z000  | A=A | r
+ or   n          | F6 nn    |    8   | z000  | A=A | n
+ or   (HL)       | B6       |    8   | z000  | A=A | (HL)
+ cp   r          | Bx       |    4   | z1hc  | compare A-r
+ cp   n          | FE nn    |    8   | z1hc  | compare A-n
+ cp   (HL)       | BE       |    8   | z1hc  | compare A-(HL)
+ inc  r          | xx       |    4   | z0h-  | r=r+1
+ inc  (HL)       | 34       |   12   | z0h-  | (HL)=(HL)+1
+ dec  r          | xx       |    4   | z1h-  | r=r-1
+ dec  (HL)       | 35       |   12   | z1h-  | (HL)=(HL)-1
+ daa             | 27       |    4   | z-0x  | decimal adjust A
+ cpl             | 2F       |    4   | -11-  | A = A xor FF
 
-### GMB Rotate and Shift Commands
+### 16-bit Arithmetic/logical instructions
 
-```
- rlca           07           4 000c rotate akku left
- rla            17           4 000c rotate akku left through carry
- rrca           0F           4 000c rotate akku right
- rra            1F           4 000c rotate akku right through carry
- rlc  r         CB 0x        8 z00c rotate left
- rlc  (HL)      CB 06       16 z00c rotate left
- rl   r         CB 1x        8 z00c rotate left through carry
- rl   (HL)      CB 16       16 z00c rotate left through carry
- rrc  r         CB 0x        8 z00c rotate right
- rrc  (HL)      CB 0E       16 z00c rotate right
- rr   r         CB 1x        8 z00c rotate right through carry
- rr   (HL)      CB 1E       16 z00c rotate right through carry
- sla  r         CB 2x        8 z00c shift left arithmetic (b0=0)
- sla  (HL)      CB 26       16 z00c shift left arithmetic (b0=0)
- swap r         CB 3x        8 z000 exchange low/hi-nibble
- swap (HL)      CB 36       16 z000 exchange low/hi-nibble
- sra  r         CB 2x        8 z00c shift right arithmetic (b7=b7)
- sra  (HL)      CB 2E       16 z00c shift right arithmetic (b7=b7)
- srl  r         CB 3x        8 z00c shift right logical (b7=0)
- srl  (HL)      CB 3E       16 z00c shift right logical (b7=0)
-```
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ add  HL,rr      | x9       |    8   | -0hc  | HL = HL+rr     ; rr may be BC,DE,HL,SP
+ inc  rr         | x3       |    8   | ----  | rr = rr+1      ; rr may be BC,DE,HL,SP
+ dec  rr         | xB       |    8   | ----  | rr = rr-1      ; rr may be BC,DE,HL,SP
+ add  SP,dd      | E8       |   16   | 00hc  | SP = SP +/- dd ; dd is 8-bit signed number
+ ld   HL,SP+dd   | F8       |   12   | 00hc  | HL = SP +/- dd ; dd is 8-bit signed number
 
-### GMB Single-bit Operation Commands
+### Rotate and Shift instructions
 
-```
- bit  n,r       CB xx        8 z01- test bit n
- bit  n,(HL)    CB xx       12 z01- test bit n
- set  n,r       CB xx        8 ---- set bit n
- set  n,(HL)    CB xx       16 ---- set bit n
- res  n,r       CB xx        8 ---- reset bit n
- res  n,(HL)    CB xx       16 ---- reset bit n
-```
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ rlca            | 07       |    4   | 000c  | rotate A left
+ rla             | 17       |    4   | 000c  | rotate A left through carry
+ rrca            | 0F       |    4   | 000c  | rotate A right
+ rra             | 1F       |    4   | 000c  | rotate A right through carry
+ rlc  r          | CB 0x    |    8   | z00c  | rotate left
+ rlc  (HL)       | CB 06    |   16   | z00c  | rotate left
+ rl   r          | CB 1x    |    8   | z00c  | rotate left through carry
+ rl   (HL)       | CB 16    |   16   | z00c  | rotate left through carry
+ rrc  r          | CB 0x    |    8   | z00c  | rotate right
+ rrc  (HL)       | CB 0E    |   16   | z00c  | rotate right
+ rr   r          | CB 1x    |    8   | z00c  | rotate right through carry
+ rr   (HL)       | CB 1E    |   16   | z00c  | rotate right through carry
+ sla  r          | CB 2x    |    8   | z00c  | shift left arithmetic (b0=0)
+ sla  (HL)       | CB 26    |   16   | z00c  | shift left arithmetic (b0=0)
+ swap r          | CB 3x    |    8   | z000  | exchange low/hi-nibble
+ swap (HL)       | CB 36    |   16   | z000  | exchange low/hi-nibble
+ sra  r          | CB 2x    |    8   | z00c  | shift right arithmetic (b7=b7)
+ sra  (HL)       | CB 2E    |   16   | z00c  | shift right arithmetic (b7=b7)
+ srl  r          | CB 3x    |    8   | z00c  | shift right logical (b7=0)
+ srl  (HL)       | CB 3E    |   16   | z00c  | shift right logical (b7=0)
 
-### GMB CPU Control Commands
+### Single-bit Operation instructions
 
-```
- ccf            3F           4 -00c cy=cy xor 1
- scf            37           4 -001 cy=1
- nop            00           4 ---- no operation
- halt           76         N*4 ---- halt until interrupt occurs (low power)
- stop           10 00        ? ---- low power standby mode (VERY low power)
- di             F3           4 ---- disable interrupts, IME=0
- ei             FB           4 ---- enable interrupts, IME=1
-```
-### GMB Jump Commands
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ bit  n,r        | CB xx    |    8   | z01-  | test bit n
+ bit  n,(HL)     | CB xx    |   12   | z01-  | test bit n
+ set  n,r        | CB xx    |    8   | ----  | set bit n
+ set  n,(HL)     | CB xx    |   16   | ----  | set bit n
+ res  n,r        | CB xx    |    8   | ----  | reset bit n
+ res  n,(HL)     | CB xx    |   16   | ----  | reset bit n
 
-```
- jp   nn        C3 nn nn    16 ---- jump to nn, PC=nn
- jp   HL        E9           4 ---- jump to HL, PC=HL
- jp   f,nn      xx nn nn 16;12 ---- conditional jump if nz,z,nc,c
- jr   PC+dd     18 dd       12 ---- relative jump to nn (PC=PC+8-bit signed)
- jr   f,PC+dd   xx dd     12;8 ---- conditional relative jump if nz,z,nc,c
- call nn        CD nn nn    24 ---- call to nn, SP=SP-2, (SP)=PC, PC=nn
- call f,nn      xx nn nn 24;12 ---- conditional call if nz,z,nc,c
- ret            C9          16 ---- return, PC=(SP), SP=SP+2
- ret  f         xx        20;8 ---- conditional return if nz,z,nc,c
- reti           D9          16 ---- return and enable interrupts (IME=1)
- rst  n         xx          16 ---- call to 00,08,10,18,20,28,30,38
-```
+### CPU Control instructions
+
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ ccf             | 3F       |    4   | -00c  | cy=cy xor 1
+ scf             | 37       |    4   | -001  | cy=1
+ nop             | 00       |    4   | ----  | no operation
+ halt            | 76       |  N*4   | ----  | halt until interrupt occurs (low power)
+ stop            | 10 00    |    ?   | ----  | low power standby mode (VERY low power)
+ di              | F3       |    4   | ----  | disable interrupts, IME=0
+ ei              | FB       |    4   | ----  | enable interrupts, IME=1
+
+### Jump instructions
+
+Mnemonic         | Encoding | Cycles | Flags | Description
+-----------------|----------|--------|-------|-------------
+ jp   nn         | C3 nn nn |   16   | ----  | jump to nn, PC=nn
+ jp   HL         | E9       |    4   | ----  | jump to HL, PC=HL
+ jp   f,nn       | xx nn nn | 16/12  | ----  | conditional jump if nz,z,nc,c
+ jr   PC+dd      | 18 dd    |   12   | ----  | relative jump to nn (PC=PC+8-bit signed)
+ jr   f,PC+dd    | xx dd    |  12/8  | ----  | conditional relative jump if nz,z,nc,c
+ call nn         | CD nn nn |   24   | ----  | call to nn, SP=SP-2, (SP)=PC, PC=nn
+ call f,nn       | xx nn nn | 24/12  | ----  | conditional call if nz,z,nc,c
+ ret             | C9       |   16   | ----  | return, PC=(SP), SP=SP+2
+ ret  f          | xx       |  20/8  | ----  | conditional return if nz,z,nc,c
+ reti            | D9       |   16   | ----  | return and enable interrupts (IME=1)
+ rst  n          | xx       |   16   | ----  | call to 00,08,10,18,20,28,30,38

--- a/content/CPU_Registers_and_Flags.md
+++ b/content/CPU_Registers_and_Flags.md
@@ -1,28 +1,25 @@
 ### Registers
 
-
- 16-bit|Hi|Lo|Name/Function
-:-----:|:-----:|:-----:|:-----:
- AF| A| -| Accumulator & Flags
- BC| B| C| BC
- DE| D| E| DE
- HL| H| L| HL
- SP| -| -| Stack Pointer
- PC| -| -| Program Counter/Pointer
-
+16-bit |Hi |Lo | Name/Function
+-------|---|---|--------------
+   AF  | A | - | Accumulator & Flags
+   BC  | B | C | BC
+   DE  | D | E | DE
+   HL  | H | L | HL
+   SP  | - | - | Stack Pointer
+   PC  | - | - | Program Counter/Pointer
 
 As shown above, most registers can be accessed either as one 16-bit
 register, or as two separate 8-bit registers.
 
-### The Flag Register (lower 8-bit of AF register)
+### The Flags Register (lower 8 bits of AF register)
 
-Bit|Name|Set|Clr|Expl.
-:-----:|:-----:|:-----:|:-----:|:-----:
-7|zf|Z|NZ|Zero Flag
-6|n| -|-|Add/Sub-Flag (BCD)
-5|h| -|-|Half Carry Flag (BCD)
-4|cy|C|NC|Carry Flag
-
+Bit | Name | Explanation
+----|------|-------
+  7 |   z  | Zero flag
+  6 |   n  | Add/Sub flag (BCD)
+  5 |   h  | Half Carry flag (BCD)
+  4 |   c  | Carry flag
 
 Contains the result from the recent instruction which has affected
 flags.

--- a/content/External_Connectors.md
+++ b/content/External_Connectors.md
@@ -1,18 +1,17 @@
 ## Cartridge Slot
 
-```
- Pin   Name    Expl.
- 1     VDD     Power Supply +5V DC
- 2     PHI     System Clock
- 3     /WR     Write
- 4     /RD     Read
- 5     /CS     Chip Select
- 6-21  A0-A15  Address Lines
- 22-29 D0-D7   Data Lines
- 30    /RES    Reset signal
- 31    VIN     External Sound Input
- 32    GND     Ground
-```
+ Pin  | Name   | Explanation
+------|--------|--------------
+  1   | VDD    | Power Supply +5V DC
+  2   | PHI    | System Clock
+  3   | /WR    | Write
+  4   | /RD    | Read
+  5   | /CS    | Chip Select
+ 6-21 | A0-A15 | Address Lines
+22-29 | D0-D7  | Data Lines
+  30  | /RES   | Reset signal
+  31  | VIN    | External Sound Input
+  32  | GND    | Ground
 
 ## Link Port
 
@@ -21,30 +20,27 @@ outside view of Game Boy socket; flat side of socket upside. Colors as
 used in most or all standard link cables, because SIN and SOUT are
 crossed, colors Red and Orange are exchanged at one cable end.
 
-```
- Pin Name Color  Expl.
- 1   VCC  -      +5V DC
- 2   SOUT red    Data Out
- 3   SIN  orange Data In
- 4   P14  -      Not used
- 5   SCK  green  Shift Clock
- 6   GND  blue   Ground
-```
+Pin | Name | Color  | Explanation
+----|------|--------|-------------
+  1 | VCC  | -      | +5V DC
+  2 | SOUT | red    | Data Out
+  3 | SIN  | orange | Data In
+  4 | P14  | -      | Not used
+  5 | SCK  | green  | Shift Clock
+  6 | GND  | blue   | Ground
 
-Note: The original Game Boy used larger plugs than Game Boy pocket and
+Note: The original Game Boy used larger plugs than Game Boy Pocket and
 newer. Linking between older/newer Game Boy systems is possible by using cables
 with one large and one small plug though.
 
 ## Stereo Sound Connector (3.5mm, female)
 
-```
- Pin     Expl.
- Tip     Sound Left
- Middle  Sound Right
- Base    Ground
-```
+ Pin    | Explanation
+--------|-----------
+ Tip    | Sound Left
+ Middle | Sound Right
+ Base   | Ground
 
 ## External Power Supply
 
 ...
-

--- a/content/Gameboy_Camera.md
+++ b/content/Gameboy_Camera.md
@@ -14,21 +14,11 @@ be found in the following github repository:
 Integrated circuits on the main board
 -------------------------------------
 
-+-------------+----------------------+----------------------+
-| Component\# | Part\# / inscription | Description          |
-+=============+======================+======================+
-| U1          | MAC-GBD\             | I/O, memory control? |
-|             | Nintendo\            |                      |
-|             | 9807 SA              |                      |
-+-------------+----------------------+----------------------+
-| U2          | GBD-PCAX-0 F\        | 1M X 8 ROM           |
-|             | M538011-E -08\       |                      |
-|             | 8145507              |                      |
-+-------------+----------------------+----------------------+
-| U3          | 52CV1000SF85LL\      | 128K X 8 RAM         |
-|             | SHARP JAPAN\         |                      |
-|             | 9805 5 0A            |                      |
-+-------------+----------------------+----------------------+
+| Component\# | Part\# / inscription                       | Description          |
+|-------------|--------------------------------------------|----------------------|
+| U1          | MAC-GBD<br>Nintendo<br>9807 SA             | I/O, memory control? |
+| U2          | GBD-PCAX-0 F<br>M538011-E -08<br>8145507   | 1M X 8 ROM           |
+| U3          | 52CV1000SF85LL<br>SHARP JAPAN<br>9805 5 0A | 128K X 8 RAM         |
 
 Pictures of the innards
 -----------------------

--- a/content/Gameboy_Printer.md
+++ b/content/Gameboy_Printer.md
@@ -21,14 +21,14 @@ The packets all follow this format:
 
 |                       | Size (bytes) | GB -> Printer | Printer -> GB |
 |-----------------------|--------------|---------------|---------------|
-| Magic bytes           | 2            | $88, $33      | 0x00          |
-| Command               | 1            | See below     | 0x00          |
-|  Compression flag     | 1            | 0/1           | 0x00          |
-| Length of data        | 2            | LSB, MSB      | 0x00          |
-| Command-specific data | Variable     | See below     | 0x00          |
-| Checksum              | 2            | LSB, MSB      | 0x00          |
-| Alive indicator       | 1            |               | 0x00          |
-| Status                | 1            | See below     | 0x00          |
+| Magic bytes           | 2            | $88, $33      | $00           |
+| Command               | 1            | See below     | $00           |
+|  Compression flag     | 1            | 0/1           | $00           |
+| Length of data        | 2            | LSB, MSB      | $00           |
+| Command-specific data | Variable     | See below     | $00           |
+| Checksum              | 2            | LSB, MSB      | $00           |
+| Alive indicator       | 1            |               | $00           |
+| Status                | 1            | See below     | $00           |
 
 The checksum is simply a sum of every byte sent except the magic bytes
 and obviously, the checksum itself.
@@ -86,18 +86,18 @@ Status byte
 -----------
 
 A nonzero value for the higher nibble indicates something went wrong.
-```
-  ------- -------------------- -------------------------------------------------------------------
-  Bit 7   Low Battery          Set when the voltage is below threshold
-  Bit 6   Other error          
-  Bit 5   Paper jam            Set when the encoder gives no pulses when the motor is powered
-  Bit 4   Packet error         
-  Bit 3   Unprocessed data     Set when there's unprocessed data in memory - AKA ready to print
-  Bit 2   Image data full      
-  Bit 1   Currently printing   Set as long as the printer's burnin' paper
-  Bit 0   Checksum error       Set when the calculated checksum doesn't match the received one
-  ------- -------------------- -------------------------------------------------------------------
-```
+
+Bit \# | Name                | Description
+-------|---------------------|---------------
+   7   | Low Battery         | Set when the voltage is below threshold
+   6   | Other error         |
+   5   | Paper jam           | Set when the encoder gives no pulses when the motor is powered
+   4   | Packet error        |
+   3   | Unprocessed data    | Set when there's unprocessed data in memory - AKA ready to print
+   2   | Image data full     |
+   1   | Currently printing  | Set as long as the printer's burnin' paper
+   0   | Checksum error      | Set when the calculated checksum doesn't match the received one
+
 Example
 -------
 

--- a/content/HuC1.md
+++ b/content/HuC1.md
@@ -9,12 +9,13 @@ I took a look, and it turns out that HuC1 differs from MBC1 quite a lot.
 Memory Map
 ----------
 
-`   0000-1FFF   IR select`
-`   2000-3FFF   ROM bank select`
-`   4000-5FFF   RAM bank select`
-`   6000-7FFF   Nothing?`
-`   --`
-`   A000-BFFF   Cart RAM or IR register`
+Address range | Feature
+--------------|---------------------------
+  $0000-1FFF  | RAM/IR select (when writing only)
+  $2000-3FFF  | ROM bank select (when writing only)
+  $4000-5FFF  | RAM bank select (when writing only)
+  $6000-7FFF  | Nothing?
+  $A000-BFFF  | Cart RAM or IR register
 
 0000-1FFF IR Select (Write Only)
 --------------------------------
@@ -57,4 +58,3 @@ External links
 --------------
 
 -   [Source on jrra.zone](http://jrra.zone/blog/huc1.html)
-

--- a/content/MBC1.md
+++ b/content/MBC1.md
@@ -1,6 +1,6 @@
 (max 2MByte ROM and/or 32KByte RAM)
 
-This is the first MBC chip for the Game Boy. Any newer MBC chips 
+This is the first MBC chip for the Game Boy. Any newer MBC chips
 work similarly, so it is relatively easy to upgrade a program from one
 MBC chip to another - or to make it compatible with several different
 types of MBCs.
@@ -42,7 +42,7 @@ power down of the Game Boy. Usually the following values are used:
 
 ```
 00h  Disable RAM (default)
-0Ah  Enable RAM`
+0Ah  Enable RAM
 ```
 
 Practically any value with 0Ah in the lower 4 bits enables RAM and any

--- a/content/MBC6.md
+++ b/content/MBC6.md
@@ -94,15 +94,15 @@ The commands and access sequences are as follows, were X refers to
 either 4 or 6 and Y to 5 or 7, depending on the bank region:
 
 ```
-  ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------------
-  2:Y555=$AA   1:XAAA=$55   2:Y555=$80   2:Y555=$AA   1:XAAA=$55   ?:X000=$30   Erase sector\* (set 8 kB region to $FFs)
-  2:Y555=$AA   1:XAAA=$55   2:Y555=$80   2:Y555=$AA   1:XAAA=$55   ?:Y555=$10   Erase chip\* (set entire flash to $FFs)
-  2:Y555=$AA   1:XAAA=$55   2:Y555=$90                                             ID mode (reads out JEDEC ID (C2,81) at $X000)
-  2:Y555=$AA   1:XAAA=$55   2:Y555=$A0                                             Program mode\*
-  2:Y555=$AA   1:XAAA=$55   2:Y555=$F0                                             Exit ID/erase chip mode
-  2:Y555=$AA   1:XAAA=$55   ?:X000=$F0                                             Exit erase sector mode
-  ?:????=$F0                                                                         Exit program mode
-  ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------------
+------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------------
+2:Y555=$AA    1:XAAA=$55    2:Y555=$80    2:Y555=$AA    1:XAAA=$55    ?:X000=$30    Erase sector\* (set 8 kB region to $FFs)
+2:Y555=$AA    1:XAAA=$55    2:Y555=$80    2:Y555=$AA    1:XAAA=$55    ?:Y555=$10    Erase chip\* (set entire flash to $FFs)
+2:Y555=$AA    1:XAAA=$55    2:Y555=$90                                                 ID mode (reads out JEDEC ID (C2,81) at $X000)
+2:Y555=$AA    1:XAAA=$55    2:Y555=$A0                                                 Program mode\*
+2:Y555=$AA    1:XAAA=$55    2:Y555=$F0                                                 Exit ID/erase chip mode
+2:Y555=$AA    1:XAAA=$55    ?:X000=$F0                                                 Exit erase sector mode
+?:????=$F0                                                                               Exit program mode
+------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------------
 ```
 
 Commands marked with \* require the Write Enable bit to be 1. These will

--- a/content/Memory_Map.md
+++ b/content/Memory_Map.md
@@ -74,17 +74,17 @@ FF) and checking if said value is mirrored in Echo RAM and not cart SRAM.
 The Game Boy uses the following I/O ranges:
 
 | **Start** | **End** | **Revision** | **Purpose** |
-|-|-|-|-|
-| FF00 | FF02 | DMG | Port/Mode |
-| FF04 | FF07 | DMG | Port/Mode |
-| FF10 | FF26 | DMG | Sound |
-| FF30 | FF3F | DMG | Waveform RAM |
-| FF40 | FF4B | DMG | LCD |
-| FF4F | | CGB | VRAM Bank Select |
-| FF50 | | DMG | Set to non-zero to disable boot ROM |
-| FF51 | FF55 | CGB | HDMA |
-| FF68 | FF69 | CGB | BCP/OCP |
-| FF70 | | CGB | WRAM Bank Select |
+|-----------|---------|--------------|-------------|
+|   $FF00   |  $FF02  |     DMG      | Port/Mode
+|   $FF04   |  $FF07  |     DMG      | Port/Mode
+|   $FF10   |  $FF26  |     DMG      | Sound
+|   $FF30   |  $FF3F  |     DMG      | Waveform RAM
+|   $FF40   |  $FF4B  |     DMG      | LCD
+|   $FF4F   |         |     CGB      | VRAM Bank Select
+|   $FF50   |         |     DMG      | Set to non-zero to disable boot ROM
+|   $FF51   |  $FF55  |     CGB      | HDMA
+|   $FF68   |  $FF69  |     CGB      | BCP/OCP
+|   $FF70   |         |     CGB      | WRAM Bank Select
 
 # FEA0-FEFF range
 

--- a/content/SGB_Functions.md
+++ b/content/SGB_Functions.md
@@ -132,11 +132,13 @@ as described above.
 ### Separating between SGB and SGB2
 
 It is also possible to separate between SGB and SGB2 models by examining
-the inital value of the accumulator (A-register) directly after startup.
+the inital value of the accumulator (register A) directly after startup.
 
-- 01h - SGB or original Game Boy (DMG)`
-- FFh - SGB2 or Game Boy Pocket
-- 11h - CGB or GBA
+Value | Console
+------|---------
+ $01  | SGB or original Game Boy (DMG)
+ $FF  | SGB2 or Game Boy Pocket
+ $11  | CGB or GBA
 
 Because values 01h and FFh are shared for both handhelds and SGBs, it is
 still required to use the above MLT_REQ detection procedure. As far as
@@ -160,9 +162,11 @@ to LOW, this will reset and start the SNES packet receiving program.
 Data is then transferred (LSB first), setting P14=LOW will indicate a
 "0" bit, and setting P15=LOW will indicate a "1" bit. For example:
 
-`      RESET 0   0   1   1   0   1   0`<br>
-` P14  --_---_---_-----------_-------_--...`<br>
-` P15  --_-----------_---_-------_------...`<br>
+```
+    RESET  0   0   1   1   0   1   0
+P14  --_---_---_-----------_-------_--...
+P15  --_-----------_---_-------_------...
+```
 
 Data and reset pulses must be kept LOW for at least 5us. P14 and P15
 must be kept both HIGH for at least 15us between any pulses. Obviously,
@@ -176,21 +180,21 @@ flag).
 
 Each packet is invoked by a RESET pulse, then 128 bits of data are
 transferred (16 bytes, LSB of first byte first), and finally, a
-"0"-bit must be transferred as stop bit. The structure of normal
-packets is:
+"0" bit must be transferred as stop bit. The structure of normal
+packets thus is:
 
-`  1 PULSE Reset`<br>
-`  1 BYTE  Command Code*8+Length`<br>
-` 15 BYTES Parameter Data`<br>
-`  1 BIT   Stop Bit (0)`<br>
+1. 1 pulse: Start signal
+2. 1 byte: Header byte (Command Code \* 8 + Length)
+3. 15 bytes: Parameter Data
+4. 1 bit: Stop Bit (0)
 
 The above "Length" indicates the total number of packets (1-7,
 including the first packet) which will be sent.  If more than 15
 parameter bytes are used, then further packet(s) will follow, as such:
 
-`  1 PULSE Reset`<br>
-` 16 BYTES Parameter Data`<br>
-`  1 BIT   Stop Bit (0)`<br>
+1. 1 pulse: Start signal
+2. 16 bytes: Parameter Data
+3. 1 bit: Stop Bit (0)
 
 By using all 7 packets, up to 111 data bytes (15+16\*6) may be sent.
 Unused bytes at the end of the last packet don't matter. A 60ms (4
@@ -244,32 +248,33 @@ the presence of SGB hardware before blindly sending VRAM data.
 
 ### SGB System Command Table
 
-` Code Name      Expl.`<br>
-` 00   PAL01     Set SGB Palette 0,1 Data`<br>
-` 01   PAL23     Set SGB Palette 2,3 Data`<br>
-` 02   PAL03     Set SGB Palette 0,3 Data`<br>
-` 03   PAL12     Set SGB Palette 1,2 Data`<br>
-` 04   ATTR_BLK  "Block" Area Designation Mode`<br>
-` 05   ATTR_LIN  "Line" Area Designation Mode`<br>
-` 06   ATTR_DIV  "Divide" Area Designation Mode`<br>
-` 07   ATTR_CHR  "1CHR" Area Designation Mode`<br>
-` 08   SOUND     Sound On/Off`<br>
-` 09   SOU_TRN   Transfer Sound PRG/DATA`<br>
-` 0A   PAL_SET   Set SGB Palette Indirect`<br>
-` 0B   PAL_TRN   Set System Color Palette Data`<br>
-` 0C   ATRC_EN   Enable/disable Attraction Mode`<br>
-` 0D   TEST_EN   Speed Function`<br>
-` 0E   ICON_EN   SGB Function`<br>
-` 0F   DATA_SND  SUPER NES WRAM Transfer 1`<br>
-` 10   DATA_TRN  SUPER NES WRAM Transfer 2`<br>
-` 11   MLT_REG   Controller 2 Request`<br>
-` 12   JUMP      Set SNES Program Counter`<br>
-` 13   CHR_TRN   Transfer Character Font Data`<br>
-` 14   PCT_TRN   Set Screen Data Color Data`<br>
-` 15   ATTR_TRN  Set Attribute from ATF`<br>
-` 16   ATTR_SET  Set Data to ATF`<br>
-` 17   MASK_EN   Game Boy Window Mask`<br>
-` 18   OBJ_TRN   Super NES OBJ Mode`<br>
+Code | Name     | Explanation
+-----|----------|--------------
+ $00 | PAL01    | Set SGB Palette 0 &amp; 1
+ $01 | PAL23    | Set SGB Palette 2 &amp; 3
+ $02 | PAL03    | Set SGB Palette 0 &amp; 3
+ $03 | PAL12    | Set SGB Palette 1 &amp; 2
+ $04 | ATTR_BLK | "Block" Area Designation Mode
+ $05 | ATTR_LIN | "Line" Area Designation Mode
+ $06 | ATTR_DIV | "Divide" Area Designation Mode
+ $07 | ATTR_CHR | "1CHR" Area Designation Mode
+ $08 | SOUND    | Sound On/Off
+ $09 | SOU_TRN  | Transfer Sound PRG/DATA
+ $0A | PAL_SET  | Set SGB Palette Indirect
+ $0B | PAL_TRN  | Set System Color Palette Data
+ $0C | ATRC_EN  | Enable/disable Attraction Mode
+ $0D | TEST_EN  | Speed Function
+ $0E | ICON_EN  | SGB Function
+ $0F | DATA_SND | SUPER NES WRAM Transfer 1
+ $10 | DATA_TRN | SUPER NES WRAM Transfer 2
+ $11 | MLT_REG  | Controller 2 Request
+ $12 | JUMP     | Set SNES Program Counter
+ $13 | CHR_TRN  | Transfer Character Font Data
+ $14 | PCT_TRN  | Set Screen Data Color Data
+ $15 | ATTR_TRN | Set Attribute from ATF
+ $16 | ATTR_SET | Set Data to ATF
+ $17 | MASK_EN  | Game Boy Window Mask
+ $18 | OBJ_TRN  | Super NES OBJ Mode
 
 # SGB Color Palettes Overview
 
@@ -285,8 +290,10 @@ these palettes are used. Palettes 4-7 are used for the SGB Border, all
 
 Colors are encoded as 16-bit RGB numbers, in the following way:
 
-` FEDC BA98 7654 3210`<br>
-` 0BBB BBGG GGGR RRRR`<br>
+```
+FEDC BA98 7654 3210
+0BBB BBGG GGGR RRRR
+```
 
 Here's a formula to convert 24-bit RGB into SNES format:
 `(color & 0xF8) << 7 | (color & 0xF800) >> 6 | (color & 0xF80000) >> 19`<br>
@@ -310,19 +317,21 @@ Because the SGB/SNES reads out the Game Boy video controllers display
 signal, it translates the different grayshades from the signal into SNES
 colors as such:
 
-` White       -->  Color 0`<br>
-` Light Gray  -->  Color 1`<br>
-` Dark Gray   -->  Color 2`<br>
-` Black       -->  Color 3`<br>
+```
+White       -->  Color #0
+Light Gray  -->  Color #1
+Dark Gray   -->  Color #2
+Black       -->  Color #3
+```
 
 Note that Game Boy colors 0-3 are assigned to user-selectable grayshades
-by the Game Boy's BGP, OBP1, and OBP2 registers. There is thus no fixed
+by the Game Boy's BGP, OBP0, and OBP1 registers. There is thus no fixed
 relationship between Game Boy colors 0-3 and SNES colors 0-3.
 
 #### Using Game Boy BGP/OBP Registers
 
 A direct translation of GB color 0-3 into SNES color 0-3 may be produced
-by setting BGP/OBP registers to a value of 0E4h each. However, in case
+by setting BGP/OBPx registers to a value of 0E4h each. However, in case
 that your program uses black background for example, then you may
 internally assign background as "White" at the Game Boy side by BGP/OBP
 registers (which is then interpreted as SNES color 0, which is shared
@@ -604,11 +613,11 @@ All 16-bit values are little-endian.
 
 Possible destinations in APU-RAM are:
 
-```
-  $0400-2AFF  APU-RAM Program Area (9.75KBytes)
-  $2B00-4AFF  APU-RAM Sound Score Area (8Kbytes)
-  $4DB0-EEFF  APU-RAM Sampling Data Area (40.25 Kbytes)
-```
+Memory range | Description
+-------------|-------------
+ $0400-2AFF  | APU-RAM Program Area (9.75KBytes)
+ $2B00-4AFF  | APU-RAM Sound Score Area (8Kbytes)
+ $4DB0-EEFF  | APU-RAM Sampling Data Area (40.25 Kbytes)
 
 This function may be used to take control of the SNES sound chip, and/or
 to access the SNES MIDI engine. In either case it requires deeper
@@ -904,13 +913,15 @@ active.
 When having enabled multiple controllers by MLT_REQ, data for each
 joypad can be read out through JOYPAD register (FF00) as follows: First
 set P14 and P15 both HIGH (deselect both Buttons and Cursor keys), you
-can now read the lower 4bits of FF00 which indicate the joypad ID for
+can now read the lower 4 bits of $FF00 which indicate the joypad ID for
 the following joypad input:
 
-` 0Fh  Joypad 1`<br>
-` 0Eh  Joypad 2`<br>
-` 0Dh  Joypad 3`<br>
-` 0Ch  Joypad 4`<br>
+Byte | Player \#
+-----|-----------
+ $0F | 1
+ $0E | 2
+ $0D | 3
+ $0C | 4
 
 Next, read joypad state as normally. When completed, set P14 and P15
 back HIGH, this automatically increments the joypad number (or restarts

--- a/content/Serial_Data_Transfer_(Link_Cable).md
+++ b/content/Serial_Data_Transfer_(Link_Cable).md
@@ -56,12 +56,12 @@ In Non-CGB Mode the Game Boy supplies an internal clock of 8192Hz only
 In CGB Mode four internal clock rates are available, depending on Bit 1
 of the SC register, and on whether the CGB Double Speed Mode is used:
 
-```
-   8192Hz -  1KB/s - Bit 1 cleared, Normal
-  16384Hz -  2KB/s - Bit 1 cleared, Double Speed Mode
- 262144Hz - 32KB/s - Bit 1 set,     Normal
- 524288Hz - 64KB/s - Bit 1 set,     Double Speed Mode
-```
+Clock freq | Transfer speed | Conditions
+-----------|----------------|------------
+   8192Hz  |      1KB/s     | Bit 1 cleared, Normal speed
+  16384Hz  |      2KB/s     | Bit 1 cleared, Double-speed Mode
+ 262144Hz  |     32KB/s     | Bit 1 set,     Normal speed
+ 524288Hz  |     64KB/s     | Bit 1 set,     Double-speed Mode
 
 ### External Clock
 

--- a/content/Sound_Controller.md
+++ b/content/Sound_Controller.md
@@ -3,12 +3,10 @@ SO2. There is also a input terminal Vin connected to the cartridge. It
 can be routed to either of both output terminals. Game Boy circuitry
 allows producing sound in four different ways:
 
-```
-Quadrangular wave patterns with sweep and envelope functions
-Quadrangular wave patterns with envelope functions
-Voluntary wave patterns from wave RAM
-White noise with an envelope function
-```
+- Quadrangular wave patterns with sweep and envelope functions (CH1)
+- Quadrangular wave patterns with envelope functions (CH2)
+- Voluntary wave patterns from wave RAM (CH3)
+- White noise with an envelope function (CH4)
 
 These four sounds can be controlled independently and then mixed
 separately for each of the output terminals.
@@ -31,16 +29,16 @@ Sound registers may be set at all times while producing sound.
 
 Sweep Time:
 
-```
-000: sweep off - no freq change
-001: 7.8 ms  (1/128Hz)
-010: 15.6 ms (2/128Hz)
-011: 23.4 ms (3/128Hz)
-100: 31.3 ms (4/128Hz)
-101: 39.1 ms (5/128Hz)
-110: 46.9 ms (6/128Hz)
-111: 54.7 ms (7/128Hz)
-```
+Value (binary) | Description
+---------------|-------------
+  000          | sweep off - no freq change
+  001          | 7.8 ms  (1/128Hz)
+  010          | 15.6 ms (2/128Hz)
+  011          | 23.4 ms (3/128Hz)
+  100          | 31.3 ms (4/128Hz)
+  101          | 39.1 ms (5/128Hz)
+  110          | 46.9 ms (6/128Hz)
+  111          | 54.7 ms (7/128Hz)
 
 The change of frequency (NR13,NR14) at each shift is calculated by the
 following formula where X(0) is initial freq & X(t-1) is last freq:
@@ -54,16 +52,14 @@ Bit 7-6 - Wave Pattern Duty (Read/Write)
 Bit 5-0 - Sound length data (Write Only) (t1: 0-63)
 ```
 
-Wave Duty:
+Bits 7-6 | Wave duty
+---------|-------------
+  %00    | 12.5% (`_-------_-------_-------`)
+  %01    | 25%   (`__------__------__------`)
+  %10    | 50%   (`____----____----____----`) (normal)
+  %11    | 75%   (`______--______--______--`)
 
-```
-00: 12.5% ( _-------_-------_------- )
-01: 25%   ( __------__------__------ )
-10: 50%   ( ____----____----____---- ) (normal)
-11: 75%   ( ______--______--______-- )
-```
-
-Sound Length = (64-t1)\*(1/256) seconds The Length value is used only if
+Sound Length = (64-t1)\*(1/256) seconds. The Length value is used only if
 Bit 6 in NR14 is set.
 
 ### FF12 - NR12 - Channel 1 Volume Envelope (R/W)
@@ -98,27 +94,31 @@ This sound channel works exactly as channel 1, except that it doesn't
 have a Tone Envelope/Sweep Register.
 
 ### FF16 - NR21 - Channel 2 Sound Length/Wave Pattern Duty (R/W)
+
 ```
 Bit 7-6 - Wave Pattern Duty (Read/Write)`
 Bit 5-0 - Sound length data (Write Only) (t1: 0-63)`
 ```
-Wave Duty:
-```
-00: 12.5% ( _-------_-------_------- )`
-01: 25%   ( __------__------__------ )`
-10: 50%   ( ____----____----____---- ) (normal)`
-11: 75%   ( ______--______--______-- )`
-```
-Sound Length = (64-t1)\*(1/256) seconds The Length value is used only if
+
+Bits 7-6 | Wave duty
+---------|-------------
+  %00    | 12.5% (`_-------_-------_-------`)
+  %01    | 25%   (`__------__------__------`)
+  %10    | 50%   (`____----____----____----`) (normal)
+  %11    | 75%   (`______--______--______--`)
+
+Sound Length = (64-t1)\*(1/256) seconds. The Length value is used only if
 Bit 6 in NR24 is set.
 
 ### FF17 - NR22 - Channel 2 Volume Envelope (R/W)
+
 ```
 Bit 7-4 - Initial Volume of envelope (0-0Fh) (0=No Sound)`
 Bit 3   - Envelope Direction (0=Decrease, 1=Increase)`
 Bit 2-0 - Number of envelope sweep (n: 0-7)`
           (If zero, stop envelope operation.)`
 ```
+
 Length of 1 step = n\*(1/64) seconds
 
 ### FF18 - NR23 - Channel 2 Frequency lo data (W)
@@ -127,12 +127,14 @@ Frequency's lower 8 bits of 11 bit data (x). Next 3 bits are in NR24
 ($FF19).
 
 ### FF19 - NR24 - Channel 2 Frequency hi data (R/W)
+
 ```
 Bit 7   - Initial (1=Restart Sound)     (Write Only)`
 Bit 6   - Counter/consecutive selection (Read/Write)`
           (1=Stop output when length in NR21 expires)`
 Bit 2-0 - Frequency's higher 3 bits (x) (Write Only)`
 ```
+
 Frequency = 131072/(2048-x) Hz
 
 # Sound Channel 3 - Wave Output
@@ -143,13 +145,15 @@ be also used to output normal tones when initializing the Wave RAM by a
 square wave. This channel doesn't have a volume envelope register.
 
 ### FF1A - NR30 - Channel 3 Sound on/off (R/W)
+
 ```
-Bit 7 - Sound Channel 3 Off  (0=Stop, 1=Playback)  (Read/Write)`
+Bit 7 - Sound Channel 3 Off  (0=Stop, 1=Playback)  (Read/Write)
 ```
 
 ### FF1B - NR31 - Channel 3 Sound Length
+
 ```
-Bit 7-0 - Sound length (t1: 0 - 255)`
+Bit 7-0 - Sound length (t1: 0 - 255)
 ```
 
 Sound Length = (256-t1)\*(1/256) seconds This value is used only if Bit
@@ -157,31 +161,37 @@ Sound Length = (256-t1)\*(1/256) seconds This value is used only if Bit
 
 ### FF1C - NR32 - Channel 3 Select output level (R/W)
 
-Bit 6-5 - Select output level (Read/Write)`
+```
+Bits 6-5 - Select output level (Read/Write)
+```
 
-Possible Output levels are:
-```
-0: Mute (No sound)`
-1: 100% Volume (Produce Wave Pattern RAM Data as it is)`
-2:  50% Volume (Produce Wave Pattern RAM data shifted once to the right)`
-3:  25% Volume (Produce Wave Pattern RAM data shifted twice to the right)`
-```
+Bits 6-5 | Output level
+---------|--------------
+  %00    | Mute (No sound)
+  %01    | 100% volume (Produce Wave Pattern RAM Data as it is)
+  %10    |  50% volume (Produce Wave Pattern RAM data shifted once to the right)
+  %11    |  25% volume (Produce Wave Pattern RAM data shifted twice to the right)
+
 ### FF1D - NR33 - Channel 3 Frequency's lower data (W)
 
 Lower 8 bits of an 11 bit frequency (x).
 
 ### FF1E - NR34 - Channel 3 Frequency's higher data (R/W)
+
 ```
 Bit 7   - Initial (1=Restart Sound)     (Write Only)`
 Bit 6   - Counter/consecutive selection (Read/Write)`
           (1=Stop output when length in NR31 expires)`
 Bit 2-0 - Frequency's higher 3 bits (x) (Write Only)`
 ```
+
 Frequency = 4194304/(64\*(2048-x)) Hz = 65536/(2048-x) Hz
 
 ### FF30-FF3F - Wave Pattern RAM
 
-Contents - Waveform storage for arbitrary sound data`
+```
+Contents - Waveform storage for arbitrary sound data
+```
 
 This storage area holds 32 4-bit samples that are played back, upper 4
 bits first.

--- a/content/The_Cartridge_Header.md
+++ b/content/The_Cartridge_Header.md
@@ -11,7 +11,7 @@ followed by a `jp $0150` instruction. But not always.
 ### 0104-0133 - Nintendo Logo
 
 These bytes define the bitmap of the Nintendo logo that is displayed
-when the Game Boy gets turned on. The hexdump of this bitmap is:
+when the Game Boy gets turned on. The hex dump of this bitmap is:
 ```
  CE ED 66 66 CC 0D 00 0B 03 73 00 83 00 0C 00 0D
  00 08 11 1F 88 89 00 0E DC CC 6E E6 DD DD D9 99
@@ -61,76 +61,76 @@ games are using the header entry at `$014B` instead.
 
 Sample licensee codes :
 
-|Code|Publisher|
-|----|---------|
-|`00`|   none |
-|`01`|   Nintendo R&D1  |
-|`08`|   Capcom |
-|`13`|   Electronic Arts  |
-|`18`|   Hudson Soft  |
-|`19`|   b-ai |
-|`20`|   kss  |
-|`22`|   pow  |
-|`24`|   PCM Complete |
-|`25`|   san-x  |
-|`28`|   Kemco Japan  |
-|`29`|   seta |
-|`30`|   Viacom |
-|`31`|   Nintendo |
-|`32`|   Bandai |
-|`33`|   Ocean/Acclaim  |
-|`34`|   Konami |
-|`35`|   Hector |
-|`37`|   Taito  |
-|`38`|   Hudson |
-|`39`|   Banpresto  |
-|`41`|   Ubi Soft |
-|`42`|   Atlus  |
-|`44`|   Malibu |
-|`46`|   angel  |
-|`47`|   Bullet-Proof |
-|`49`|   irem |
-|`50`|   Absolute |
-|`51`|   Acclaim  |
-|`52`|   Activision |
-|`53`|   American sammy |
-|`54`|   Konami |
-|`55`|   Hi tech entertainment  |
-|`56`|   LJN  |
-|`57`|   Matchbox |
-|`58`|   Mattel |
-|`59`|   Milton Bradley |
-|`60`|   Titus  |
-|`61`|   Virgin |
-|`64`|   LucasArts  |
-|`67`|   Ocean  |
-|`69`|   Electronic Arts  |
-|`70`|   Infogrames |
-|`71`|   Interplay  |
-|`72`|   Broderbund |
-|`73`|   sculptured |
-|`75`|   sci  |
-|`78`|   THQ  |
-|`79`|   Accolade |
-|`80`|   misawa |
-|`83`|   lozc |
-|`86`|   Tokuma Shoten Intermedia |
-|`87`|   Tsukuda Original |
-|`91`|   Chunsoft |
-|`92`|   Video system |
-|`93`|   Ocean/Acclaim  |
-|`95`|   Varie  |
-|`96`|   Yonezawa/s'pal |
-|`97`|   Kaneko |
-|`99`|   Pack in soft |
-|`A4`|   Konami (Yu-Gi-Oh!) |
+|Code| Publisher
+|----|-----------
+|`00`| None
+|`01`| Nintendo R&D1
+|`08`| Capcom
+|`13`| Electronic Arts
+|`18`| Hudson Soft
+|`19`| b-ai
+|`20`| kss
+|`22`| pow
+|`24`| PCM Complete
+|`25`| san-x
+|`28`| Kemco Japan
+|`29`| seta
+|`30`| Viacom
+|`31`| Nintendo
+|`32`| Bandai
+|`33`| Ocean/Acclaim
+|`34`| Konami
+|`35`| Hector
+|`37`| Taito
+|`38`| Hudson
+|`39`| Banpresto
+|`41`| Ubi Soft
+|`42`| Atlus
+|`44`| Malibu
+|`46`| angel
+|`47`| Bullet-Proof
+|`49`| irem
+|`50`| Absolute
+|`51`| Acclaim
+|`52`| Activision
+|`53`| American sammy
+|`54`| Konami
+|`55`| Hi tech entertainment
+|`56`| LJN
+|`57`| Matchbox
+|`58`| Mattel
+|`59`| Milton Bradley
+|`60`| Titus
+|`61`| Virgin
+|`64`| LucasArts
+|`67`| Ocean
+|`69`| Electronic Arts
+|`70`| Infogrames
+|`71`| Interplay
+|`72`| Broderbund
+|`73`| sculptured
+|`75`| sci
+|`78`| THQ
+|`79`| Accolade
+|`80`| misawa
+|`83`| lozc
+|`86`| Tokuma Shoten Intermedia
+|`87`| Tsukuda Original
+|`91`| Chunsoft
+|`92`| Video system
+|`93`| Ocean/Acclaim
+|`95`| Varie
+|`96`| Yonezawa/s'pal
+|`97`| Kaneko
+|`99`| Pack in soft
+|`A4`| Konami (Yu-Gi-Oh!)
 
 ### 0146 - SGB Flag
 
 Specifies whether the game supports SGB functions, common values are:
 
-- `$00` : No SGB functions (Normal Game Boy or CGB only game)
-- `$03` : Game supports SGB functions
+- `$00`: No SGB functions (Normal Game Boy or CGB only game)
+- `$03`: Game supports SGB functions
 
 The SGB disables its SGB functions if this byte is set to a value other than `$03`.
 
@@ -139,36 +139,36 @@ The SGB disables its SGB functions if this byte is set to a value other than `$0
 Specifies which Memory Bank Controller (if any) is used in the
 cartridge, and if further external hardware exists in the cartridge.
 
-|Code| Type|
-|-----|-----------|
-|`$00`|  ROM ONLY|
-|`$01`|  MBC1|
-|`$02`|  MBC1+RAM |
-|`$03`|  MBC1+RAM+BATTERY|
-|`$05`|  MBC2|
-|`$06`|  MBC2+BATTERY|
-|`$08`|  ROM+RAM|
-|`$09`|  ROM+RAM+BATTERY |
-|`$0B`|  MMM01|
-|`$0C`|  MMM01+RAM|
-|`$0D`|  MMM01+RAM+BATTERY|
-|`$0F`|  MBC3+TIMER+BATTERY|
-|`$10`|  MBC3+TIMER+RAM+BATTERY|
-|`$11`|  MBC3|
-|`$12`|  MBC3+RAM|
-|`$13`|  MBC3+RAM+BATTERY|
-|`$19`|  MBC5|
-|`$1A`|  MBC5+RAM|
-|`$1B`|  MBC5+RAM+BATTERY|
-|`$1C`|  MBC5+RUMBLE|
-|`$1D`|  MBC5+RUMBLE+RAM|
-|`$1E`|  MBC5+RUMBLE+RAM+BATTERY|
-|`$20`|  MBC6|
-|`$22`|  MBC7+SENSOR+RUMBLE+RAM+BATTERY|
-|`$FC`|  POCKET CAMERA|
-|`$FD`|  BANDAI TAMA5|
-|`$FE`|  HuC3|
-|`$FF`|  HuC1+RAM+BATTERY|
+|Code | Type
+|-----|------
+| $00 | ROM ONLY
+| $01 | MBC1
+| $02 | MBC1+RAM
+| $03 | MBC1+RAM+BATTERY
+| $05 | MBC2
+| $06 | MBC2+BATTERY
+| $08 | ROM+RAM
+| $09 | ROM+RAM+BATTERY
+| $0B | MMM01
+| $0C | MMM01+RAM
+| $0D | MMM01+RAM+BATTERY
+| $0F | MBC3+TIMER+BATTERY
+| $10 | MBC3+TIMER+RAM+BATTERY
+| $11 | MBC3
+| $12 | MBC3+RAM
+| $13 | MBC3+RAM+BATTERY
+| $19 | MBC5
+| $1A | MBC5+RAM
+| $1B | MBC5+RAM+BATTERY
+| $1C | MBC5+RUMBLE
+| $1D | MBC5+RUMBLE+RAM
+| $1E | MBC5+RUMBLE+RAM+BATTERY
+| $20 | MBC6
+| $22 | MBC7+SENSOR+RUMBLE+RAM+BATTERY
+| $FC | POCKET CAMERA
+| $FD | BANDAI TAMA5
+| $FE | HuC3
+| $FF | HuC1+RAM+BATTERY
 
 
 ### 0148 - ROM Size
@@ -176,36 +176,36 @@ cartridge, and if further external hardware exists in the cartridge.
 Specifies the ROM Size of the cartridge. Typically calculated as "N such that 32 KiB
 << N".
 
-|code | Size      | Banks |
-|-----|-----------|--------------|
-|`$00`|  32 KByte |2 banks <br> (No ROM banking)|
-|`$01`|  64 KByte |4 banks|
-|`$02`| 128 KByte |8 banks|
-|`$03`| 256 KByte |16 banks|
-|`$04`| 512 KByte |32 banks|
-|`$05`|   1 MByte |64 banks|
-|`$06`|   2 MByte |128 banks|
-|`$07`|   4 MByte |256 banks|
-|`$08`|   8 MByte |512 banks|
-|`$52`| 1.1 MByte |72 banks|
-|`$53`| 1.2 MByte |80 banks|
-|`$54`| 1.5 MByte |96 banks|
+|Code | Size      | Amount of banks
+|-----|-----------|-----------------
+| $00 |  32 KByte | 2 (No ROM banking)
+| $01 |  64 KByte | 4
+| $02 | 128 KByte | 8
+| $03 | 256 KByte | 16
+| $04 | 512 KByte | 32
+| $05 |   1 MByte | 64
+| $06 |   2 MByte | 128
+| $07 |   4 MByte | 256
+| $08 |   8 MByte | 512
+| $52 | 1.1 MByte | 72
+| $53 | 1.2 MByte | 80
+| $54 | 1.5 MByte | 96
 
 
 ### 0149 - RAM Size
 
 Specifies the size of the external RAM in the cartridge (if any).
 
-```
- $00 - None
- $01 - 2 KBytes
- $02 - 8 KBytes
- $03 - 32 KBytes (4 banks of 8KBytes each)
- $04 - 128 KBytes (16 banks of 8KBytes each)
- $05 - 64 KBytes (8 banks of 8KBytes each)
-```
+| Code | Size   | Comment
+|------|--------|---------
+| $00  | 0      | No RAM
+| $01  | 2 KB   | Partial
+| $02  | 8 KB   | 1 bank
+| $03  | 32 KB  | 4 banks of 8 KB each
+| $04  | 128 KB | 16 banks of 8 KB each
+| $05  | 64 KB  | 8 banks of 8 KB each
 
-When using a MBC2 chip $00 must be specified in this entry, even though
+When using a MBC2 chip, $00 must be specified in this entry, even though
 the MBC2 includes a built-in RAM of 512 x 4 bits.
 
 ### 014A - Destination Code
@@ -213,10 +213,8 @@ the MBC2 includes a built-in RAM of 512 x 4 bits.
 Specifies if this version of the game is supposed to be sold in Japan,
 or anywhere else. Only two values are defined.
 
-```
-$00 - Japanese
-$01 - Non-Japanese
-```
+- $00: Japanese
+- $01: Non-Japanese
 
 ### 014B - Old Licensee Code
 

--- a/content/Video_Display.md
+++ b/content/Video_Display.md
@@ -42,12 +42,12 @@ that memory is inaccessible to the CPU.
 -   During mode 3, the CPU cannot access VRAM or CGB Palette Data
     (FF69,FF6B).
 
-| Mode    | Action                                                                | Duration                                                           | Accessible video memory |
-|---------|-----------------------------------------------------------------------|--------------------------------------------------------------------|-------------------------|
-|2        |Scanning OAM for (X, Y) coordinates of sprites that overlap this line  |80 dots (19 us)                                                     |VRAM, CGB palettes       |
-|3        |Reading OAM and VRAM to generate the picture                           |168 to 291 dots (40 to 60 us) depending on sprite count           |None                     |
-|0        |Horizontal blanking                                                    |85 to 208 dots (20 to 49 us) depending on previous mode 3 duration  |VRAM, OAM, CGB palettes  |
-|1        |Vertical blanking                                                      |4560 dots (1087 us, 10 scanlines)                                   |VRAM, OAM, CGB palettes  |
+| Mode    | Action                                                                | Duration                                                           | Accessible video memory
+|---------|-----------------------------------------------------------------------|--------------------------------------------------------------------|-------------------------
+|    2    | Scanning OAM for (X, Y) coordinates of sprites that overlap this line | 80 dots (19 us)                                                    | VRAM, CGB palettes
+|    3    | Reading OAM and VRAM to generate the picture                          | 168 to 291 dots (40 to 60 us) depending on sprite count            | None
+|    0    | Horizontal blanking                                                   | 85 to 208 dots (20 to 49 us) depending on previous mode 3 duration | VRAM, OAM, CGB palettes
+|    1    | Vertical blanking                                                     | 4560 dots (1087 us, 10 scanlines)                                  | VRAM, OAM, CGB palettes
 
 ### Properties of STAT modes
 
@@ -158,20 +158,18 @@ This register assigns gray shades to the color numbers of the BG and
 Window tiles.
 
 ```
-Bit 7-6 - Shade for Color Number 3
-Bit 5-4 - Shade for Color Number 2
-Bit 3-2 - Shade for Color Number 1
-Bit 1-0 - Shade for Color Number 0
+Bit 7-6 - Color for index 3
+Bit 5-4 - Color for index 2
+Bit 3-2 - Color for index 1
+Bit 1-0 - Color for index 0
 ```
 
-The four possible gray shades are:
-
-```
-0  White
-1  Light gray
-2  Dark gray
-3  Black
-```
+Value | Color
+------|-------
+  0   | White
+  1   | Light gray
+  2   | Dark gray
+  3   | Black
 
 In CGB Mode the Color Palettes are taken from CGB Palette Memory
 instead.


### PR DESCRIPTION
Except bit descriptions and SGB packets, as style needs to be agreed upon.
Also fixes afferent issues (mainly style).

Fixes #114