### PR TITLE
Improve grammar

### DIFF
--- a/content/Video_Display.md
+++ b/content/Video_Display.md
@@ -674,7 +674,7 @@ lower-priority sprite's OBJ-to-BG Priority.
 
 The recommended method is to write the data to normal RAM first, and to
 copy that RAM to OAM by using the DMA transfer function, initiated
-through DMA register (FF46). Beside for that, it is also possible to
+through DMA register (FF46). Besides, it is also possible to
 write data directly to the OAM area by using normal LD commands, but this
 works only during the H-Blank and V-Blank periods. The current state of
 the LCD controller can be read out from the STAT register (FF41).


### PR DESCRIPTION
This was fixed in a previous patch but was accidentally undone when a later patch was applied.