### PR TITLE
do not pretend that Non-CGB mode also uses video and RAM banks

### DIFF
--- a/content/Memory_Map.md
+++ b/content/Memory_Map.md
@@ -3,20 +3,20 @@ The Game Boy has a 16-bit address bus, which is used to address ROM, RAM, and I/
 # General Memory Map
 
 
-| **Start**   | **End**   | **Description**                                                                                  | **Notes**|
-|-------------|-----------|--------------------------------------------------------------------------------------------------|-----------|
-| 0000        | 3FFF      | 16KB ROM bank 00                                                                                 | From cartridge, usually a fixed bank|
-| 4000        | 7FFF      | 16KB ROM Bank 01\~NN                                                                             | From cartridge, switchable bank via [MB](#memory-bank-controllers) (if any)|
-| 8000        | 9FFF      | 8KB Video RAM (VRAM)                                                                             | Only bank 0 in Non-CGB mode Switchable bank 0/1 in CGB mode |
-| A000        | BFFF      | 8KB External RAM                                                                                 | In cartridge, switchable bank if any
-| C000        | CFFF      | 4KB Work RAM (WRAM) bank 0                                                                       | |
-| D000        | DFFF      | 4KB Work RAM (WRAM) bank 1\~N                                                                    | Only bank 1 in Non-CGB mode Switchable bank 1\~7 in CGB mode |
-| E000        | FDFF      | Mirror of C000\~DDFF (ECHO RAM)                                                                  | Nintendo says use of this area is prohibited. |
-| FE00        | FE9F      | Sprite attribute table ([OAM](#vram-sprite-attribute-table-oam))   | |
-| FEA0        | FEFF      | Not Usable                                                                                       | Nintendo says use of this area is prohibited |
-| FF00        | FF7F      | I/O Registers                                                                                    | |
-| FF80        | FFFE      | High RAM (HRAM)                                                                                  | |
-| FFFF        | FFFF      | [Interrupts](#interrupts) Enable Register (IE)                                         | |
+| **Start**   | **End**   | **Description**                                                  | **Notes**
+|-------------|-----------|------------------------------------------------------------------|----------
+| 0000        | 3FFF      | 16KB ROM bank 00                                                 | From cartridge, usually a fixed bank
+| 4000        | 7FFF      | 16KB ROM Bank 01\~NN                                             | From cartridge, switchable bank via [MB](#memory-bank-controllers) (if any)
+| 8000        | 9FFF      | 8KB Video RAM (VRAM)                                             | In CGB mode, switchable bank 0/1
+| A000        | BFFF      | 8KB External RAM                                                 | In cartridge, switchable bank if any
+| C000        | CFFF      | 4KB Work RAM (WRAM)                                              | In CGB mode, bank 0
+| D000        | DFFF      | 4KB Work RAM (WRAM)                                              | In CGB mode, switchable bank 1\~7
+| E000        | FDFF      | Mirror of C000\~DDFF (ECHO RAM)                                  | Nintendo says use of this area is prohibited.
+| FE00        | FE9F      | Sprite attribute table ([OAM](#vram-sprite-attribute-table-oam)) |
+| FEA0        | FEFF      | Not Usable                                                       | Nintendo says use of this area is prohibited
+| FF00        | FF7F      | I/O Registers                                                    |
+| FF80        | FFFE      | High RAM (HRAM)                                                  |
+| FFFF        | FFFF      | [Interrupts](#interrupts) Enable Register (IE)                   |
 
 # Jump Vectors in first ROM bank
 

--- a/content/Memory_Map.md
+++ b/content/Memory_Map.md
@@ -6,9 +6,9 @@ The Game Boy has a 16-bit address bus, which is used to address ROM, RAM, and I/
 | **Start**   | **End**   | **Description**                                                  | **Notes**
 |-------------|-----------|------------------------------------------------------------------|----------
 | 0000        | 3FFF      | 16KB ROM bank 00                                                 | From cartridge, usually a fixed bank
-| 4000        | 7FFF      | 16KB ROM Bank 01\~NN                                             | From cartridge, switchable bank via [MB](#memory-bank-controllers) (if any)
+| 4000        | 7FFF      | 16KB ROM Bank 01\~NN                                             | From cartridge, switchable bank via [mapper](#memory-bank-controllers) (if any)
 | 8000        | 9FFF      | 8KB Video RAM (VRAM)                                             | In CGB mode, switchable bank 0/1
-| A000        | BFFF      | 8KB External RAM                                                 | In cartridge, switchable bank if any
+| A000        | BFFF      | 8KB External RAM                                                 | From cartridge, switchable bank if any
 | C000        | CFFF      | 4KB Work RAM (WRAM)                                              | In CGB mode, bank 0
 | D000        | DFFF      | 4KB Work RAM (WRAM)                                              | In CGB mode, switchable bank 1\~7
 | E000        | FDFF      | Mirror of C000\~DDFF (ECHO RAM)                                  | Nintendo says use of this area is prohibited.

--- a/content/Memory_Map.md
+++ b/content/Memory_Map.md
@@ -5,12 +5,12 @@ The Game Boy has a 16-bit address bus, which is used to address ROM, RAM, and I/
 
 | **Start**   | **End**   | **Description**                                                  | **Notes**
 |-------------|-----------|------------------------------------------------------------------|----------
-| 0000        | 3FFF      | 16KB ROM bank 00                                                 | From cartridge, usually a fixed bank
-| 4000        | 7FFF      | 16KB ROM Bank 01\~NN                                             | From cartridge, switchable bank via [mapper](#memory-bank-controllers) (if any)
-| 8000        | 9FFF      | 8KB Video RAM (VRAM)                                             | In CGB mode, switchable bank 0/1
-| A000        | BFFF      | 8KB External RAM                                                 | From cartridge, switchable bank if any
-| C000        | CFFF      | 4KB Work RAM (WRAM)                                              |
-| D000        | DFFF      | 4KB Work RAM (WRAM)                                              | In CGB mode, switchable bank 1\~7
+| 0000        | 3FFF      | 16 KiB ROM bank 00                                               | From cartridge, usually a fixed bank
+| 4000        | 7FFF      | 16 KiB ROM Bank 01\~NN                                           | From cartridge, switchable bank via [mapper](#memory-bank-controllers) (if any)
+| 8000        | 9FFF      | 8 KiB Video RAM (VRAM)                                           | In CGB mode, switchable bank 0/1
+| A000        | BFFF      | 8 KiB External RAM                                               | From cartridge, switchable bank if any
+| C000        | CFFF      | 4 KiB Work RAM (WRAM)                                            |
+| D000        | DFFF      | 4 KiB Work RAM (WRAM)                                            | In CGB mode, switchable bank 1\~7
 | E000        | FDFF      | Mirror of C000\~DDFF (ECHO RAM)                                  | Nintendo says use of this area is prohibited.
 | FE00        | FE9F      | Sprite attribute table ([OAM](#vram-sprite-attribute-table-oam)) |
 | FEA0        | FEFF      | Not Usable                                                       | Nintendo says use of this area is prohibited

--- a/content/Memory_Map.md
+++ b/content/Memory_Map.md
@@ -9,7 +9,7 @@ The Game Boy has a 16-bit address bus, which is used to address ROM, RAM, and I/
 | 4000        | 7FFF      | 16KB ROM Bank 01\~NN                                             | From cartridge, switchable bank via [mapper](#memory-bank-controllers) (if any)
 | 8000        | 9FFF      | 8KB Video RAM (VRAM)                                             | In CGB mode, switchable bank 0/1
 | A000        | BFFF      | 8KB External RAM                                                 | From cartridge, switchable bank if any
-| C000        | CFFF      | 4KB Work RAM (WRAM)                                              | In CGB mode, bank 0
+| C000        | CFFF      | 4KB Work RAM (WRAM)                                              |
 | D000        | DFFF      | 4KB Work RAM (WRAM)                                              | In CGB mode, switchable bank 1\~7
 | E000        | FDFF      | Mirror of C000\~DDFF (ECHO RAM)                                  | Nintendo says use of this area is prohibited.
 | FE00        | FE9F      | Sprite attribute table ([OAM](#vram-sprite-attribute-table-oam)) |


### PR DESCRIPTION
remove unneeded spaces in the table while we are at it.