### PR TITLE
Add HTML internal link checker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 jobs:
-  build:
+  run-tests:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout gbdev/pandocs
@@ -48,7 +48,8 @@ jobs:
     - name: Install XeLaTeX
       run: sudo apt-get install texlive-xetex
 
-    - working-directory: folder/
+    - name: Check anchor links consistency and empty sections
+      working-directory: folder/
       run: |
         cd repo/render
         ./merge.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Publish 
+
+on:
+  pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout gbdev/pandocs
+      uses: actions/checkout@v2
+      with:
+        repository: gbdev/pandocs
+        path: folder/repo
+
+    - name: Checkout gbdev/pandocs master
+      uses: actions/checkout@v2
+      with:
+        repository: gbdev/pandocs
+        ref: master
+        path: folder/build
+
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r folder/repo/render/requirements.txt
+
+    - name: Install npm dependencies
+      working-directory: folder/repo/render
+      run: |
+        npm install
+
+    - name: Install pandoc
+      uses: r-lib/actions/setup-pandoc@v1
+      with:
+        pandoc-version: '2.7.3'
+
+    - name: Install XeLaTeX
+      run: sudo apt-get install texlive-xetex
+
+    - working-directory: folder/
+      run: |
+        cd repo/render
+        ./merge.sh
+        npm run build
+        python3 checkanchors.py .vuepress/dist/index.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Publish 
+name: Run tests
 
 on:
   pull_request

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 on:
-  pull_request
+  [pull_request, push]
 
 jobs:
   run-tests:

--- a/render/checkanchors.py
+++ b/render/checkanchors.py
@@ -114,6 +114,8 @@ def main(argv=None):
     else:
         with open(args.output, "w", encoding="utf-8") as outfp:
             outfp.writelines(out)
+    if out:
+        sys.exit(1)
 
 if __name__=='__main__':
     if 'idlelib' in sys.modules:

--- a/render/proposed/checkanchors.py
+++ b/render/proposed/checkanchors.py
@@ -1,18 +1,45 @@
 #!/usr/bin/env python3
+"""
+checkanchors, an internal link checker
+
+Copyright 2021 Damian Yerrick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
 import os
 import sys
 import argparse
 import html5lib
 import xml.etree.ElementTree as ET
 
-helpText="Checks an HTML file for missing anchors."
+helpText="Checks an HTML file for missing internal anchors."
+versionText = """checkanchors v0.01
+Copyright 2021 Damian Yerrick
+This is free software under the MIT License (Expat variant)."""
 
 def parse_argv(argv):
     p = argparse.ArgumentParser(description=helpText)
+    p.add_argument('--version', action='version', version=versionText)
     p.add_argument("input", default="-",
-                   help="name of HTML file to check")
+                   help="name of HTML file to check (or - for standard input)")
     p.add_argument("-o", "--output", default="-",
-                   help="where to write the diagnosis")
+                   help="where to write the diagnostic (default: standard output)")
     return p.parse_args(argv[1:])
 
 def main(argv=None):
@@ -81,9 +108,12 @@ def main(argv=None):
         out.append("\n")
     errs = []
 
-    sys.stdout.writelines(out)
-    
-
+    # Write the report.  Will be empty if no errors.
+    if args.output == '-':
+        sys.stdout.writelines(out)
+    else:
+        with open(args.output, "w", encoding="utf-8") as outfp:
+            outfp.writelines(out)
 
 if __name__=='__main__':
     if 'idlelib' in sys.modules:

--- a/render/proposed/checkanchors.py
+++ b/render/proposed/checkanchors.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import os
+import sys
+import argparse
+import html5lib
+import xml.etree.ElementTree as ET
+
+helpText="Checks an HTML file for missing anchors."
+
+def parse_argv(argv):
+    p = argparse.ArgumentParser(description=helpText)
+    p.add_argument("input", default="-",
+                   help="name of HTML file to check")
+    p.add_argument("-o", "--output", default="-",
+                   help="where to write the diagnosis")
+    return p.parse_args(argv[1:])
+
+def main(argv=None):
+    args = parse_argv(argv or sys.argv)
+    if args.input == "-":
+        body = sys.stdin.read()
+    else:
+        with open(args.input, "r", encoding="utf-8") as infp:
+            body = infp.read()
+    doc = html5lib.parse(body, treebuilder="etree", namespaceHTMLElements=False)
+    out = []
+
+    # Look for multiple IDs
+    els = doc.findall(".//*[@id]")
+    seen_ids, errs = {}, []
+    for el in els:
+        idvalue = el.get("id")
+        textcontent = " ".join(ET.tostring(el, "unicode", "text").split())
+        try:
+            oldtext = seen_ids[idvalue]
+        except KeyError:
+            seen_ids[idvalue], oldtext = textcontent, None
+        else:
+            errs.append('id="%s"\n    %s\n    %s\n'
+                        % (idvalue, oldtext, textcontent))
+    if errs:
+        out.append("IDs seen multiple times\n")
+        out.extend(errs)
+        out.append("\n")
+        
+    seen_ids, errs = set(seen_ids), []
+
+    # Look for missing anchors
+    els = doc.findall(".//a[@href]")
+    for el in els:
+        hrefvalue = el.get("href")
+        if not hrefvalue.startswith("#"): continue
+        desired_id = hrefvalue[1:]
+        if desired_id not in seen_ids:
+            outerxml = " ".join(ET.tostring(el, "unicode", "xml").split())
+            errs.append(outerxml)
+    if errs:
+        out.append("Dangling internal links (whose fragment matches no id= value)\n")
+        out.extend("    %s\n" % x for x in errs)
+        out.append("\n")
+    errs = []
+
+    # Look for consecutive headings with no text between them
+    for el in doc.iter():
+        prevel, prevtag, prevtail = None, "", ""
+        for child in el:
+            tag, tail = child.tag, (child.tail or "").strip()
+            if tag is ET.Comment or tag == "hr":
+                prevtail = prevtail + tail
+                continue
+            if (prevtag.startswith("h") and tag.startswith("h")
+                and tail == ''
+                and prevtag[1:].isdigit() and tag[1:].isdigit()):
+                prevhlevel, hlevel = int(prevtag[1:]), int(tag[1:])
+                if prevhlevel >= hlevel:
+                    errs.append(ET.tostring(prevel, "unicode", "text"))
+            prevel, prevtag, prevtail = child, child.tag, child.tail
+    if errs:
+        out.append("Empty sections\n")
+        out.extend("    %s\n" % x for x in errs)
+        out.append("\n")
+    errs = []
+
+    sys.stdout.writelines(out)
+    
+
+
+if __name__=='__main__':
+    if 'idlelib' in sys.modules:
+        main(["./checkanchors.py", "index.html"])
+    else:
+        main()

--- a/render/requirements.txt
+++ b/render/requirements.txt
@@ -1,1 +1,2 @@
 MarkdownPP==1.5.1
+html5lib==1.1


### PR DESCRIPTION
I wrote a Python script to check an HTML document for these errors:
- Same `id=` value on multiple elements
- Internal links whose fragment matches no `id=` value in the document
- Empty sections (e.g. two consecutive `<h4>` or an `<h4>` followed by an `<h2>`)

See if it's useful for #167 at all. An empty output means no errors. I have no experience with GitHub Actions, so I'll be watching edits to this PR to see what happens.