### PR TITLE
Missing register values for different GB models

### DIFF
--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -13,10 +13,9 @@ If the least significant byte of the result is a not a zero, then the Game Boy w
 If it is a zero, then the internal ROM is disabled and cartridge program execution begins at location $100 with the following register values:
 
 ```
-  A = $01-GB/SGB, $FF-GBP, $11-GBC/GBA
+  A = 0x01-GB/SGB, 0xFF-GBP/GBL/SGB2, 0x11-CGB
   F = $B0
-  B = $00-GB/SGB/GBP/GBC, $01-GBA
-  C = $13
+  BC = $0013
   DE = $00D8
   HL = $014D
   SP = $FFFE

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -13,11 +13,14 @@ If the least significant byte of the result is a not a zero, then the Game Boy w
 If it is a zero, then the internal ROM is disabled and cartridge program execution begins at location $100 with the following register values:
 
 ```
-  AF=$01B0
-  BC=$0013
-  DE=$00D8
-  HL=$014D
-  Stack Pointer=$FFFE
+  A = $01-GB/SGB, $FF-GBP, $11-GBC/GBA
+  F = $B0
+  B = $00-GB/SGB/GBP/GBC, $01-GBA
+  C = $13
+  DE = $00D8
+  HL = $014D
+  SP = $FFFE
+  PC = $0100
   [$FF05] = $00   ; TIMA
   [$FF06] = $00   ; TMA
   [$FF07] = $00   ; TAC


### PR DESCRIPTION
I found those values in historical versions of pandocs (gbspec.txt) and GB CPU Manual v 1.01.
"Detecting CGB (and GBA) functions " has both A = $11 in GBC/GBA and B = $01 in GBA  mentioned but is missing here.
This error probably occured because someone copy-pasted "Power Up Sequence" page from gbdev.gg8.se wiki which is incomplete.