### PR TITLE
Add references for GBC approval process

### DIFF
--- a/content/GBC_Approval_Process.md
+++ b/content/GBC_Approval_Process.md
@@ -26,3 +26,8 @@ At 50 percent milestone and near completion, the publisher would
 submit a ROM image to Mario Club for feedback on use of color and
 other aspects of game design.
 
+References:
+
+* ["F the Super Game Boy: Kirby's Dream Land 2"](https://loveconquersallgam.es/post/2487450388/fuck-the-super-game-boy-kirbys-dream-land-2) by Christine Love
+* ["The Making of Snoopy Tennis"](https://sidequestions.medium.com/making-snoopy-tennis-nintendo-gameboy-color-infogrames-mermaid-11bed971526d) by Alexander Hughes
+* ["License Agreement for Game Boy (Western Hemisphere)"](https://contracts.onecle.com/thq/nintendo.lic.1999.03.09.shtml)


### PR DESCRIPTION
Link to articles "F the Super Game Boy" and "The Making of Snoopy Tennis", which put together support most of the info in That Manual.