### PR TITLE
Replaced "right" by "top" in the " LCD Color Palettes" part

### DIFF
--- a/content/Video_Display.md
+++ b/content/Video_Display.md
@@ -269,7 +269,7 @@ colors mix quite oddly; increasing intensity of only one R,G,B color
 will also influence the other two R,G,B colors. For example, a color
 setting of 03EFh (Blue=0, Green=1Fh, Red=0Fh) will appear as Neon Green
 on VGA displays, but on the CGB it'll produce a decently washed out
-Yellow. See image on the right.
+Yellow. See image on the top.
 
 ### RGB Translation by GBAs
 

--- a/content/Video_Display.md
+++ b/content/Video_Display.md
@@ -269,7 +269,7 @@ colors mix quite oddly; increasing intensity of only one R,G,B color
 will also influence the other two R,G,B colors. For example, a color
 setting of 03EFh (Blue=0, Green=1Fh, Red=0Fh) will appear as Neon Green
 on VGA displays, but on the CGB it'll produce a decently washed out
-Yellow. See image on the top.
+Yellow. See the image above.
 
 ### RGB Translation by GBAs
 


### PR DESCRIPTION
The image of the CGB Palette difference between a VGA monitor and a CGB screen is not on the right but on the top