### PR TITLE
Clarify condition for triggering OAM corruption

### DIFF
--- a/content/Sprite_RAM_Bug.md
+++ b/content/Sprite_RAM_Bug.md
@@ -1,6 +1,6 @@
 There is a flaw in the Game Boy hardware that causes trash to be written
 to OAM RAM if the following instructions are used while their 16-bit content
-is in the range of $FE00 to $FEFF while the PPU is in mode 2:
+(before the operation) is in the range $FE00&ndash;$FEFF and the PPU is in mode 2:
 
 ```
  inc rr        dec rr          ;rr = bc,de, or hl


### PR DESCRIPTION
Regarding references, Liji said he has yet to publish his OAM corruption test suite, but that blargg was the best we have in the meantime.

I think it's better to wait until we can point at a specific ROM rather than linking to blargg and overshooting the scope.