### PR TITLE
Link to new `master` branch instead of defunct `develop`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -28,7 +28,7 @@ curly-quotes = true
 print = { enable = true }
 fold = { enable = true, level = 0 }
 git-repository-url = "https://github.com/gbdev/pandocs"
-edit-url-template = "https://github.com/gbdev/pandocs/edit/develop/{path}"
+edit-url-template = "https://github.com/gbdev/pandocs/edit/master/{path}"
 site-url = "/pandocs/"
 
 [output.linkcheck]

--- a/src/References.md
+++ b/src/References.md
@@ -10,7 +10,7 @@
 - [exezin. OAM DMA tutorial](https://exez.in/gameboy-dma)
 - [Furrtek - Reverse-engineered schematics for DMG-CPU-B](https://github.com/furrtek/DMG-CPU-Inside)
 - [Furrtek - Game Boy Printer](http://furrtek.free.fr/?a=gbprinter)
-- [Pan of ATX, Marat Fayzullin, Felber Pascal, Robson Paul, and Korth Martin - Pan Docs (previous versions and revisions)](https://github.com/gbdev/pandocs/tree/develop/historical)
+- [Pan of ATX, Marat Fayzullin, Felber Pascal, Robson Paul, and Korth Martin - Pan Docs (previous versions and revisions)](https://github.com/gbdev/pandocs/tree/master/historical)
 - [Jeff Frohwein - DMG, SGB, MBC schematics](http://www.devrs.com/gb/hardware.php)
 - [Pat Fagan - z80gboy.txt](http://www.z80.info/z80gboy.txt)
 - [Christine Love - F the Super Game Boy: Kirby's Dream Land 2](https://loveconquersallgam.es/post/2487450388/fuck-the-super-game-boy-kirbys-dream-land-2)


### PR DESCRIPTION
Following up on https://github.com/gbdev/pandocs/commit/c87931dde27e894d879e53a5433be108aa9d8063.