### PR TITLE
Add description of SGB detection using initial register values

### DIFF
--- a/src/SGB_Command_Multiplayer.md
+++ b/src/SGB_Command_Multiplayer.md
@@ -4,7 +4,7 @@
 
 Used to request multiplayer mode (that is, input from more than one joypad).
 Because this function provides feedback from the SGB/SNES to the Game
-Boy program, it is also used to detect SGB hardware.
+Boy program, it can also be used to detect SGB hardware.
 
 ```
  Byte  Content

--- a/src/SGB_Unlocking.md
+++ b/src/SGB_Unlocking.md
@@ -29,6 +29,9 @@ SGB     | $01        | $14
 MGB     | $FF        | $13
 SGB2    | $FF        | $14
 
+For initial register values on all systems, see the table of all [CPU
+registers after power-up](<#CPU registers>).
+
 The SGB2 doesn't have any extra features which'd require separate SGB2
 detection except for curiosity purposes, for example, the game "Tetris
 DX" chooses to display an alternate SGB border on SGB2s.

--- a/src/SGB_Unlocking.md
+++ b/src/SGB_Unlocking.md
@@ -28,6 +28,8 @@ DMG     | $01        | $13
 SGB     | $01        | $14
 MGB     | $FF        | $13
 SGB2    | $FF        | $14
+CGB     | $11        | $00
+AGB     | $11        | $00
 
 For initial register values on all systems, see the table of all [CPU
 registers after power-up](<#CPU registers>).

--- a/src/SGB_Unlocking.md
+++ b/src/SGB_Unlocking.md
@@ -16,11 +16,11 @@ SGB functions.
 ## Detecting SGB hardware
 
 SGB hardware can be detected by examining the initial value of the C
-register directly after startup. A value of $14 indicates SGB or SGB2
-hardware. It is also possible to separate between SGB and SGB2 models by
+register directly after startup: a value of $14 indicates SGB or SGB2
+hardware. It is also possible to separate between SGB and SGB2 by
 examining the initial value of the A register directly after startup.
 Note that the DMG and MGB share initial A register values with the SGB
-and SGB2.
+and SGB2 respectively.
 
 Console | A Register | C Register
 --------|------------|------------
@@ -38,16 +38,16 @@ DX" chooses to display an alternate SGB border on SGB2s.
 
 Only the SGB2 contains a link port.
 
-SGB hardware can also be detected by sending MLT_REQ commands, but this
+SGB hardware has traditionally been detected by sending [`MLT_REQ` commands](<#SGB Command 11h - MLT_REQ>), but this
 method is more complicated and slower than checking the value of the A
-and C registers after startup. The MLT_REQ command enables two (or four)
+and C registers after startup. The `MLT_REQ` command enables two (or four)
 joypads; a normal handheld Game Boy will ignore this command, but an SGB
 will return incrementing joypad IDs each time when deselecting keypad
-lines (see MLT_REQ description for details). The joypad state/IDs can
+lines ([see `MLT_REQ` description](<#Reading Multiple Controllers (Joypads)>)). The joypad state/IDs can
 then be read out several times, and if the IDs are changing, then it is
 an SGB (a normal Game Boy would typically always return $0F as the ID).
 Finally, when not intending to use more than one joypad, send another
-MLT_REQ command in order to re-disable the multi-controller mode.
+`MLT_REQ` command in order to disable the multi-controller mode.
 Detection works regardless of how many joypads are physically connected
-to the SNES. However, detection works only when having unlocked SGB
-functions in the cartridge header, as described above.
+to the SNES. However, unlike the C register method, this detection works only when
+SGB functions [are unlocked from the cartridge header](<#Cartridge Header>).

--- a/src/SGB_Unlocking.md
+++ b/src/SGB_Unlocking.md
@@ -15,34 +15,36 @@ SGB functions.
 
 ## Detecting SGB hardware
 
-The recommended detection method is to send a MLT_REQ command which
-enables two (or four) joypads. A normal handheld Game Boy will ignore
-this command, a SGB will now return incrementing joypad IDs each time
-when deselecting keyboard lines (see MLT_REQ description for details).
-Now read-out joypad state/IDs several times, and if the ID-numbers are
-changing, then it is a SGB (a normal Game Boy would typically always
-return 0Fh as ID). Finally, when not intending to use more than one
-joypad, send another MLT_REQ command in order to re-disable the
-multi-controller mode. Detection works regardless of whether and how
-many joypads are physically connected to the SNES. However, detection
-works only when having unlocked SGB functions in the cartridge header,
-as described above.
+SGB hardware can be detected by examining the initial value of the C
+register directly after startup. A value of $14 indicates SGB or SGB2
+hardware. It is also possible to separate between SGB and SGB2 models by
+examining the initial value of the A register directly after startup.
+Note that the DMG and MGB share initial A register values with the SGB
+and SGB2.
 
-## Separating between SGB and SGB2
+Console | A Register | C Register
+--------|------------|------------
+DMG     | $01        | $13
+SGB     | $01        | $14
+MGB     | $FF        | $13
+SGB2    | $FF        | $14
 
-It is also possible to separate between SGB and SGB2 models by examining
-the inital value of the accumulator (register A) directly after startup.
-
-Value | Console
-------|---------
- $01  | SGB or original Game Boy (DMG)
- $FF  | SGB2 or Game Boy Pocket
- $11  | CGB or GBA
-
-Because values 01h and FFh are shared for both handhelds and SGBs, it is
-still required to use the above MLT_REQ detection procedure. As far as
-I know the SGB2 doesn't have any extra features which'd require
-separate SGB2 detection except for curiosity purposes, for example, the
-game "Tetris DX" chooses to display an alternate SGB border on SGB2s.
+The SGB2 doesn't have any extra features which'd require separate SGB2
+detection except for curiosity purposes, for example, the game "Tetris
+DX" chooses to display an alternate SGB border on SGB2s.
 
 Only the SGB2 contains a link port.
+
+SGB hardware can also be detected by sending MLT_REQ commands, but this
+method is more complicated and slower than checking the value of the A
+and C registers after startup. The MLT_REQ command enables two (or four)
+joypads; a normal handheld Game Boy will ignore this command, but an SGB
+will return incrementing joypad IDs each time when deselecting keypad
+lines (see MLT_REQ description for details). The joypad state/IDs can
+then be read out several times, and if the IDs are changing, then it is
+an SGB (a normal Game Boy would typically always return $0F as the ID).
+Finally, when not intending to use more than one joypad, send another
+MLT_REQ command in order to re-disable the multi-controller mode.
+Detection works regardless of how many joypads are physically connected
+to the SNES. However, detection works only when having unlocked SGB
+functions in the cartridge header, as described above.


### PR DESCRIPTION
The values of $13 and $14 in the C register come from the [Mooney GB tests](https://github.com/Gekkio/mooneye-gb/tree/master/tests/acceptance) (boot_regs-*.s), double-checked with the boot ROMs at [gbdev.gg8.se](https://gbdev.gg8.se/files/roms/bootroms/).