### PR TITLE
Separate CGB Infrared section; clarify IR Receiver Adaptation

### DIFF
--- a/src/CGB_Infrared.md
+++ b/src/CGB_Infrared.md
@@ -1,0 +1,49 @@
+# CGB Infrared
+
+The GBC comes with an infrared port on the very top of the handheld,
+which can be used to send and receive IR signals via its two separate
+diodes. This functionality is not limited to other GBCs - it can be
+used to communicate with external devices as well.
+
+Note that the GBA does not include an infrared port and, as such, this
+method of communication is unavailable in its CGB compatibility mode.
+
+## FF56 - RP - Infrared Communications Port
+
+This register allows data to be transmitted and received through the
+infrared port.
+
+Bit | Name             | Usage notes                     | R/W?
+----|------------------|---------------------------------|-------------
+6-7 | Data read enable | 0=Disable, 3=Enable             | Read/Write
+ 1  | Read data        | 0=Receiving IR Signal, 1=Normal | Read Only
+ 0  | Write data       | 0=LED Off, 1=Led On             | Read/Write
+
+In order to read data, both Bit 6 and 7 must be set. Note that if Bit 0
+is not cleared, the CGB will end up reading its own IR signal.
+
+Both sending and receiving IR data increase power consumption - when not
+used, RP should be reset to 00h.
+
+## IR Receiver Adaptation
+
+The IR sensor in the GBC adapts to the current level of infrared light
+as a way to handle potential light pollution. In other words, if the
+GBC receives a sustained IR signal beyond a certain amount of time,
+eventually the sensor treats this as a new "normal" level of light,
+which causes Bit 1 of RP to go back to 1. This is called the signal
+"fade" because it may appear as if the signal disappears.
+
+The following should be kept in mind while working with the infrared
+port:
+
+* IR communication protocols should be designed with this effect in mind.
+  For example, a TV remote control may send a series of 32 LED ON/OFF
+  pulses (length 10us ON, 17.5us OFF each) instead of a permanent 880us
+  LED ON signal.
+* When enabling data read in the RP register under brighter light
+  conditions, one may initially read 0 from Bit 1, implying that an IR
+  signal is being received. As such, a short amount of time should pass
+  between writing 0xC0 to RP and attempting to read an IR signal. (TODO:
+  How much? The upper bound is known to be 3-4 ms; the lower bound
+  may be as little as 0.05-0.1 ms.)

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -191,24 +191,7 @@ TODO: confirm whether interrupts can occur (just the joypad one?) during the pau
 ### FF56 - RP - CGB Mode Only - Infrared Communications Port
 
 This register allows to input and output data through the CGBs built-in
-Infrared Port. When reading data, bit 6 and 7 must be set (and obviously
-Bit 0 must be cleared - if you don't want to receive your own Game Boy's
-IR signal). After sending or receiving data you should reset the
-register to 00h to reduce battery power consumption again.
-
-```
- Bit 0:   Write Data   (0=LED Off, 1=LED On)             (Read/Write)
- Bit 1:   Read Data    (0=Receiving IR Signal, 1=Normal) (Read Only)
- Bit 6-7: Data Read Enable (0=Disable, 3=Enable)         (Read/Write)
-```
-
-Note that the receiver will adapt itself to the normal level of IR
-pollution in the air, so if you would send a LED ON signal for a longer
-period, then the receiver would treat that as normal (=OFF) after a
-while. For example, a Philips TV Remote Control sends a series of 32 LED
-ON/OFF pulses (length 10us ON, 17.5us OFF each) instead of a permanent
-880us LED ON signal. Even though being generally CGB compatible, the GBA
-does not include an infra-red port.
+Infrared Port. For more information, see [CGB Infrared](./CGB_Infrared.md).
 
 ### FF6C - OPRI - CGB Mode Only - Object Priority Mode
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -32,6 +32,7 @@
 - [Interrupts](./Interrupts.md)
   - [Interrupt Sources](./Interrupt_Sources.md)
 - [CGB Registers](./CGB_Registers.md)
+  - [CGB Infrared](./CGB_Infrared.md)
 - [SGB Functions](./SGB_Functions.md)
   - [Unlocking and Detecting SGB Functions](./SGB_Unlocking.md)
   - [Command Packet Transfers](./SGB_Command_Packet.md)


### PR DESCRIPTION
This is based on notes from shonumi's Dan Docs, though a lot is omitted due to not being necessarily of use from a programmer's perspective or documenting the behaviour of specific games.

I've decided not to include the full detail on using RP as rudimentary light detection, but I'm fine with this being discussed further - I did include more detailed information on IR light adaptation as something to keep in mind while using the port for its intended purpose.