### PR TITLE
Switch to new "bit explanation" format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,45 +137,6 @@ For example, `[sample link text](<#014B — Old licensee code>)` will automatica
 References to missing sections will be left as-is, and ambiguous references resolved arbitrarily (this should eventually change).
 (Note that the use of angle brackets `<>` here is [a CommonMark feature](https://spec.commonmark.org/0.30/#link-destination) to allow spaces in the link destination.)
 
-### 9. Bit breakdown tables
-
-Quite often, a single byte's various bits encode different information.
-(For example, the "attributes" byte in OAM, all APU registers, and so on.)
-To describe those cases, we use a mix of custom syntax and a list:
-
-```markdown
-{{#bits 8
-  "Attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 4:"DMG palette" 3:"Bank" 2-0:"CGB palette";
-}}
-
-- **Priority**: `0` = No, `1` = BG and Window colors 1-3 over this OBJ
-- **Y flip**: `0` = Normal, `1` = Entire OBJ is vertically mirrored
-- **X flip**: `0` = Normal, `1` = Entire OBJ is horizontally mirrored
-- **DMG palette** *\[Non CGB Mode only\]*: `0` = OBP0, `1` = OBP1
-- **Bank** *\[CGB Mode Only\]*: `0` = Fetch tile in VRAM bank 0, `1` = Fetch tile in VRAM bank 1
-- **CGB palette** *\[CGB Mode Only\]*: Use OBP0-7
-```
-
-- The `{{#bits}}` tag can span several lines for readability, and must contain first its "width", i.e. how many bits (columns) there should be; then a list of rows, separated by semicolons `;` (a trailing one is allowed).
-
-  Each row begins by its name, which must be surrounded by double quotes (to allow whitespace in it).
-Then, there's a list of *fields*, separated by whitespace: first its bit range (where e.g. `3` is equivalent to `3-3`), then its name, also surrounded by double quotes.
-
-  Field names should be succinct, otherwise the table may overflow, particularly on phones.
-
-  (Note: the tag can be escaped by putting a backslash in front of the first brace: `\{{#bits ...}}`; this makes the tag not be processed.)
-
-- The list must document all of the fields with a name.
-  Each entry must first contain the name, then any "usage notes" (typically availability, or "ignored if ..." notes) between brackets `[]`, then the read/writability between parentheses.
-  Then a colon, and a description of the field.
-
-  Regarding the formatting:
-  - The name must be in **bold**, since it's really important information.
-  - Anything before the initial colon, except for the name, must be in *italics*.
-  - Any values for the field should be put in `monospace/code blocks`; this ensures they stand out.
-  - The usage notes can be omitted if there are none.
-  - For the sake of readability, if the read/writability of all fields is the same, then it must omitted in the list, but indicated e.g. in the section name, or in main text.
-
 ## SVG 
 
 ### Rationale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,6 @@ In any case, maintainers will chime in, reviewing what you changed and if necess
 
 ## Document Style
 
-
 ### 1. Pseudocode
 
 - Assignment: :=
@@ -70,7 +69,6 @@ References:
 
 Discussion:
 - [#76](https://github.com/gbdev/pandocs/issues/76), [#55](https://github.com/gbdev/pandocs/issues/55)
-
 
 ### 3. 8 bits / 8-bit
 
@@ -138,6 +136,45 @@ A convenience feature is provided for linking to sections, even across files: an
 For example, `[sample link text](<#014B — Old licensee code>)` will automatically be turned into `[sample link text](The_Cartridge_Header.html#014b--old-licensee-code)`.
 References to missing sections will be left as-is, and ambiguous references resolved arbitrarily (this should eventually change).
 (Note that the use of angle brackets `<>` here is [a CommonMark feature](https://spec.commonmark.org/0.30/#link-destination) to allow spaces in the link destination.)
+
+### 9. Bit breakdown tables
+
+Quite often, a single byte's various bits encode different information.
+(For example, the "attributes" byte in OAM, all APU registers, and so on.)
+To describe those cases, we use a mix of custom syntax and a list:
+
+```markdown
+{{#bits 8
+  "Attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 4:"DMG palette" 3:"Bank" 2-0:"CGB palette";
+}}
+
+- **Priority**: `0` = No, `1` = BG and Window colors 1-3 over this OBJ
+- **Y flip**: `0` = Normal, `1` = Entire OBJ is vertically mirrored
+- **X flip**: `0` = Normal, `1` = Entire OBJ is horizontally mirrored
+- **DMG palette** *\[Non CGB Mode only\]*: `0` = OBP0, `1` = OBP1
+- **Bank** *\[CGB Mode Only\]*: `0` = Fetch tile in VRAM bank 0, `1` = Fetch tile in VRAM bank 1
+- **CGB palette** *\[CGB Mode Only\]*: Use OBP0-7
+```
+
+- The `{{#bits}}` tag can span several lines for readability, and must contain first its "width", i.e. how many bits (columns) there should be; then a list of rows, separated by semicolons `;` (a trailing one is allowed).
+
+  Each row begins by its name, which must be surrounded by double quotes (to allow whitespace in it).
+Then, there's a list of *fields*, separated by whitespace: first its bit range (where e.g. `3` is equivalent to `3-3`), then its name, also surrounded by double quotes.
+
+  Field names should be succinct, otherwise the table may overflow, particularly on phones.
+
+  (Note: the tag can be escaped by putting a backslash in front of the first brace: `\{{#bits ...}}`; this makes the tag not be processed.)
+
+- The list must document all of the fields with a name.
+  Each entry must first contain the name, then any "usage notes" (typically availability, or "ignored if ..." notes) between brackets `[]`, then the read/writability between parentheses.
+  Then a colon, and a description of the field.
+
+  Regarding the formatting:
+  - The name must be in **bold**, since it's really important information.
+  - Anything before the initial colon, except for the name, must be in *italics*.
+  - Any values for the field should be put in `monospace/code blocks`; this ensures they stand out.
+  - The usage notes can be omitted if there are none.
+  - For the sake of readability, if the read/writability of all fields is the same, then it must omitted in the list, but indicated e.g. in the section name, or in main text.
 
 ## SVG 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,10 +691,13 @@ dependencies = [
 name = "pandocs-preproc"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap 2.34.0",
+ "lazy_static",
  "mdbook",
  "pulldown-cmark 0.8.0",
  "pulldown-cmark-to-cmark",
+ "regex",
  "serde_json",
  "termcolor",
 ]

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -130,33 +130,50 @@ Note that the angle brackets [are only required if there are spaces in the URL](
 
 In effect, this means that linking to a section is as simple as copy-pasting its name in the URL field, prepending a `#`, and wrapping everything in `<>` if the name contains a space.
 
-### Bit descriptions
+### Bit breakdown tables
+
+Quite often, a single byte's various bits, or various bytes in a collection, encode different information.
+(For example, the "attributes" byte in OAM, all APU registers, and so on.)
+To describe those cases, we use a mix of custom syntax and a list:
 
 ```markdown
-{{#bits 8 > SB 7-0:"Serial data"; SC 7:"Transfer start" 1:"Clock speed" 0:"Clock source"}}
+{{#bits 8
+  "Attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 4:"DMG palette" 3:"Bank" 2-0:"CGB palette";
+}}
+
+- **Priority**: `0` = No, `1` = BG and Window colors 1-3 over this OBJ
+- **Y flip**: `0` = Normal, `1` = Entire OBJ is vertically mirrored
+- **X flip**: `0` = Normal, `1` = Entire OBJ is horizontally mirrored
+- **DMG palette** *\[Non CGB Mode only\]*: `0` = OBP0, `1` = OBP1
+- **Bank** *\[CGB Mode Only\]*: `0` = Fetch tile in VRAM bank 0, `1` = Fetch tile in VRAM bank 1
+- **CGB palette** *\[CGB Mode Only\]*: Use OBP0-7
 ```
 
-Pan Docs describes a lot of hardware registers, and [it has been agreed upon that tables are the best format for this](https://github.com/gbdev/pandocs/issues/318).
-However, the best formatting requires `colspan`, which requires HTML tables, which are quite tedious to write; hence, a shorthand syntax was developed.
-This is typically used for bit descriptions (hence the name), but is generic enough to work e.g. for byte descriptions as well.
+- The `{{#bits}}` tag can span several lines for readability.
+  It must begin with its "width", i.e. how many bits (columns) there should be, and "direction", i.e. whether columns should be in ascending `<` or descending `>` order.
+  Then is a list of *rows*, separated by semicolons `;` (a trailing one is allowed).
 
-The first argument is the number of columns (not counting the title one).
+  Each row begins by its name, which must be surrounded by double quotes (to allow whitespace in it).
+  If the name is empty, then all rows' names must be empty; this will remove the "heading" column entirely.
 
-The second argument is the direction of the indices: `<` for increasing, `>` for decreasing.
-Decreasing is preferred for bit descriptions, and increasing for byte descriptions.
+  Then, there's a list of *fields*, separated by whitespace: first its bit range (where e.g. `3` is equivalent to `3-3`), then its name, also surrounded by double quotes.
 
-The following arguments can be repeated for as many rows as desired, separated by semicolons `;`:
-- One argument (which may not start with a digit) names the row; if exactly "\_", it will be ignored.
-- Any amount of arguments (even zero) name the individual fields, which must be ordered as in the example. Fields may span several bits, as shown above.
+  Field names should be succinct, otherwise the table may overflow, particularly on phones.
 
-Note: these are usually followed by more detailed descriptions of the fields.
-The format of those is documented [in the style guide](https://github.com/gbdev/pandocs/wiki/Document-Style#ANCHOR_FOR_ADDITION_BELOW).
+  (Note: the tag can be escaped by putting a backslash in front of the first brace: `\{{#bits ...}}`; this makes the tag not be processed.)
 
-\[THIS WILL NOT BE ADDED TO THE PR, BUT TO THE STYLE GUIDE ON THE WIKI. IT'S MERELY HERE FOR REVIEW.\]
+- The list must document all of the fields with a name.
+  Each entry must first contain the name, then any "usage notes" (typically availability, or "ignored if ..." notes) between brackets `[]`, then the read/writability between parentheses.
+  Then a colon, and a description of the field.
 
-The format of bit description lists is as follows: `- **Field name** [*Additional notes*] (*Read/Write*): Description`.
-Additional notes are, for example, to note CGB exclusivity; they are not required.
-The "Read/Write" part may be omitted if all fields within the byte are readable and writable; otherwise, it must be indicated for all fields, and both words must be fully spelled out, or spelled exactly "Read-only"/"Write-only".
+  Regarding the formatting:
+  - The name must be in **bold**, since it's really important information.
+  - Anything before the initial colon, except for the name, must be in *italics*.
+  - Any values for the field should be put in `monospace/code blocks`; this ensures they stand out.
+  - The usage notes can be omitted if there are none.
+  - For the sake of readability, if the read/writability of all fields is the same, then it must omitted in the list, but indicated e.g. in the section name, or in main text.
+
+Tables [were agreed upon](https://github.com/gbdev/pandocs/issues/318) as the best way to represent this, but Markdown does not support `colspan`, so a shorthand syntax was developed.
 
 ## Syntax highlighting
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -130,6 +130,34 @@ Note that the angle brackets [are only required if there are spaces in the URL](
 
 In effect, this means that linking to a section is as simple as copy-pasting its name in the URL field, prepending a `#`, and wrapping everything in `<>` if the name contains a space.
 
+### Bit descriptions
+
+```markdown
+{{#bits 8 > SB 7-0:"Serial data"; SC 7:"Transfer start" 1:"Clock speed" 0:"Clock source"}}
+```
+
+Pan Docs describes a lot of hardware registers, and [it has been agreed upon that tables are the best format for this](https://github.com/gbdev/pandocs/issues/318).
+However, the best formatting requires `colspan`, which requires HTML tables, which are quite tedious to write; hence, a shorthand syntax was developed.
+This is typically used for bit descriptions (hence the name), but is generic enough to work e.g. for byte descriptions as well.
+
+The first argument is the number of columns (not counting the title one).
+
+The second argument is the direction of the indices: `<` for increasing, `>` for decreasing.
+Decreasing is preferred for bit descriptions, and increasing for byte descriptions.
+
+The following arguments can be repeated for as many rows as desired, separated by semicolons `;`:
+- One argument (which may not start with a digit) names the row; if exactly "\_", it will be ignored.
+- Any amount of arguments (even zero) name the individual fields, which must be ordered as in the example. Fields may span several bits, as shown above.
+
+Note: these are usually followed by more detailed descriptions of the fields.
+The format of those is documented [in the style guide](https://github.com/gbdev/pandocs/wiki/Document-Style#ANCHOR_FOR_ADDITION_BELOW).
+
+\[THIS WILL NOT BE ADDED TO THE PR, BUT TO THE STYLE GUIDE ON THE WIKI. IT'S MERELY HERE FOR REVIEW.\]
+
+The format of bit description lists is as follows: `- **Field name** [*Additional notes*] (*Read/Write*): Description`.
+Additional notes are, for example, to note CGB exclusivity; they are not required.
+The "Read/Write" part may be omitted if all fields within the byte are readable and writable; otherwise, it must be indicated for all fields, and both words must be fully spelled out, or spelled exactly "Read-only"/"Write-only".
+
 ## Syntax highlighting
 
 Syntax highlighting is provided within the browser, courtesy of [`highlight.js`](https://github.com/highlightjs/highlight.js).

--- a/custom/style.css
+++ b/custom/style.css
@@ -155,11 +155,15 @@ mfrac msup :not(:first-child) {
 }
 
 
-table.bit-descrs th {
+.bit-descrs {
+  text-align: center;
+}
+
+.bit-descrs th {
     padding: 3px 10px;
 }
 
 /* mdBook aligns the first column, but this is not desirable for those tables */
-table.bit-descrs.nameless td:first-child {
+.bit-descrs.nameless td:first-child {
     text-align: center;
 }

--- a/custom/style.css
+++ b/custom/style.css
@@ -150,3 +150,13 @@ math[display="block"], mfrac {
 mfrac msup :not(:first-child) {
   font-size: 1.8rem;
 }
+
+
+table.bit-descrs th {
+    padding: 3px 10px;
+}
+
+/* mdBook aligns the first column, but this is not desirable for those tables */
+table.bit-descrs.nameless td:first-child {
+    text-align: center;
+}

--- a/custom/style.css
+++ b/custom/style.css
@@ -38,6 +38,9 @@ table {
     /* Alternate (Open) digits */ "ss02", /* Disambiguation gliphs */ "case";
   /* Case alternates */
 }
+th {
+  text-align: center;
+}
 
 code {
   /* "!important" needed because https://github.com/rust-lang/mdBook/issues/1552 */

--- a/preproc/Cargo.toml
+++ b/preproc/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.42"
 clap = "2.33.3"
+lazy_static = "1.4.0"
 # mdbook here is only used as a lib, so no need for the extra features
 mdbook = { version = "0.4.8", default-features = false }
 pulldown-cmark = "0.8.0"
 pulldown-cmark-to-cmark = "6.0.1"
-termcolor = "1.1.2"
+regex = "1.5.4"
 serde_json = "1.0.59"
+termcolor = "1.1.2"

--- a/preproc/src/main.rs
+++ b/preproc/src/main.rs
@@ -62,7 +62,7 @@ fn handle_preprocessing(pre: &dyn Preprocessor) -> Result<(), Error> {
 
 fn handle_supports(pre: &dyn Preprocessor, sub_args: &ArgMatches) -> ! {
     let renderer = sub_args.value_of("renderer").expect("Required argument");
-    let supported = pre.supports_renderer(&renderer);
+    let supported = pre.supports_renderer(renderer);
 
     // Signal whether the renderer is supported by exiting with 1 or 0.
     if supported {

--- a/preproc/src/preproc.rs
+++ b/preproc/src/preproc.rs
@@ -340,10 +340,14 @@ impl Pandocs {
             // Generate the table head
             if !attrs.rows[0].0.is_empty() {
                 // If names are present, add an empty cell for the name column
-                replaced.push_str("<table class=\"bit-descrs\"><thead><tr><th></th>");
+                replaced.push_str(
+                    "<div class=\"table-wrapper\"><table class=\"bit-descrs\"><thead><tr><th></th>",
+                );
             } else {
                 // Otherwise, add a class to force correct styling of first column
-                replaced.push_str("<table class=\"bit-descrs nameless\"><thead><tr>");
+                replaced.push_str(
+                    "<div class=\"table-wrapper\"><table class=\"bit-descrs nameless\"><thead><tr>",
+                );
             }
             // Start at `start`, and step each time
             for i in iter::successors(Some(start), |i| {
@@ -387,7 +391,7 @@ impl Pandocs {
                 }
                 replaced.push_str("</tr>");
             }
-            replaced.push_str("</tbody></table>");
+            replaced.push_str("</tbody></table></div>");
 
             previous_end_index = cap_end;
         }
@@ -488,7 +492,9 @@ impl<'input> BitDescrAttrs<'input> {
                     .find('"')
             }
             let Some(name_len) = parse_name(row_str) else {
-                bail!("Expected row to begin by its name (did you forget to put quotes around it?)");
+                bail!(
+                    "Expected row to begin by its name (did you forget to put quotes around it?)"
+                );
             };
             let name = &row_str[1..(name_len + 1)];
             let mut row_str = row_str[(name_len + 2)..].trim_start(); // The end is already trimmed.
@@ -518,10 +524,8 @@ impl<'input> BitDescrAttrs<'input> {
                     left.checked_sub(right)
                 }
                 .map(|len| (left, len + 1)) else {
-                    bail!(
-                        "Field must end after it started ({}-{})",
-                        left, right
-                    )};
+                    bail!("Field must end after it started ({}-{})", left, right)
+                };
 
                 if let Some(field) = fields.last() {
                     if !increasing {

--- a/src/Audio_Registers.md
+++ b/src/Audio_Registers.md
@@ -16,71 +16,62 @@ One of the pitfalls of the `NRxy` naming convention is that the register's purpo
 
 ## Global control registers
 
-### FF26 — NR52: Sound on/off
+### FF26 — NR52: Audio master control
 
-This register controls whether the APU is powered on at all (akin to [`LCDC` bit 7](<#LCDC.7 — LCD enable>)), and allows checking whether channels are active[^nr52_dac].
-Turning the APU off drains less power (around 16%), but clears all APU registers and makes them read-only until turned back on, except `NR52`[^dmg_apu_off].
+{{#bits 8 >
+  "NR52" 7:"Audio on/off" 3:"CH4 on?" 2:"CH3 on?" 1:"CH2 on?" 0:"CH1 on?"
+}}
 
-```
- Bit 7 - All sound on/off  (0: turn the APU off) (Read/Write)
- Bit 3 - Channel 4 ON flag (Read Only)
- Bit 2 - Channel 3 ON flag (Read Only)
- Bit 1 - Channel 2 ON flag (Read Only)
- Bit 0 - Channel 1 ON flag (Read Only)
-```
+- **Audio on/off** (*Read/Write*): This controls whether the APU is powered on at all (akin to [`LCDC` bit 7](<#LCDC.7 — LCD enable>)).
+  Turning the APU off drains less power (around 16%), but clears all APU registers and makes them read-only until turned back on, except `NR52`[^dmg_apu_off].
+- **CH<var>n</var> on?** (*Read-only*): Each of these four bits allows checking whether channels are active[^nr52_dac].
+  Writing to those does **not** enable or disable the channels, despite many emulators behaving as if.
 
-Bits 0-3 of this register are read-only status bits.
-Writing to those does NOT enable or disable the channels, despite many emulators behaving as if.
+  A channel is turned on by triggering it (i.e. setting bit 7 of `NRx4`)[^dac_off].
+  A channel is turned off when any of the following occurs:
+      - The channel's [length timer](<#Length timer>) is enabled in `NRx4` and expires, or
+      - *For CH1 only*: when the [period sweep](<#FF10 — NR10: Channel 1 sweep>) overflows[^freq_sweep_underflow], or
+      - [The channel's DAC](#DACs) is turned off.
+  
+  The envelope reaching a volume of 0 does NOT turn the channel off!
 
-A channel is turned on by triggering it (i.e. setting bit 7 of `NRx4`)[^dac_off].
-A channel is turned off when any of the following occurs:
-- The channel's length timer, if enabled in `NRx4`, expires
-- For CH1: when the period sweep overflows[^freq_sweep_underflow]
-- [The channel's DAC](#DACs) is turned off
-
-The envelope reaching a volume of 0 does NOT turn the channel off!
-
-[^nr52_dac]:
-Actually, the low nibble of NR52 only reports whether the channels' *generation* circuits are enabled, not if [the DACs](#DACs) are.
+<hr>
 
 [^dmg_apu_off]:
 ...and the length timers (in `NRx1`) on monochrome models.
 
+[^nr52_dac]:
+Actually, only the status of the channels' *generation* circuits is reported, not the status of [the DACs](#DACs). A channel can only be ON if its corresponding DAC is, though.
+
 [^dac_off]:
-If [the DAC](#DACs) is off, then the write to NRx4 will be ineffective and won't turn the channel on.
+If [the channel's DAC](#DACs) is off, then the write to NRx4 will be ineffective and won't turn the channel on.
 
 [^freq_sweep_underflow]:
-The period sweep cannot normally underflow, so a "decreasing" sweep (`NR10` bit 3 set) won't turn the channel off.
+The period sweep cannot normally underflow, so a "decreasing" sweep (`NR10` bit 3 set) cannot turn the channel off.
 
 ### FF25 — NR51: Sound panning
 
 Each channel can be panned hard left, center, hard right, or ignored entirely.
 
-```
-Bit 7 - Mix channel 4 into left output
-Bit 6 - Mix channel 3 into left output
-Bit 5 - Mix channel 2 into left output
-Bit 4 - Mix channel 1 into left output
-Bit 3 - Mix channel 4 into right output
-Bit 2 - Mix channel 3 into right output
-Bit 1 - Mix channel 2 into right output
-Bit 0 - Mix channel 1 into right output
-```
+{{#bits 8 >
+  "NR51" 7:"CH4 left" 6:"CH3 left" 5:"CH2 left" 4:"CH1 left" 3:"CH4 right" 2:"CH3 right" 1:"CH2 right" 0:"CH1 right"
+}}
+
+Setting a bit to 1 enables the channel to go into the selected output.
+
+Note that selecting or de-selecting a channel whose [DAC](#DACs) is enabled will [cause an audio pop](#Mixer).
 
 ### FF24 — NR50: Master volume & VIN panning
 
-The volume bits specify the master volume, i.e. how much each output should be scaled.
-A value of 0 is treated as a volume of 1 (very quiet), and a value of 7 is treated as a volume of 8 (no volume reduction).
-Importantly, the amplifier **never mutes** a non-silent input.
+{{#bits 8 >
+  "NR50" 7:"VIN left" 6-4:"Left volume" 3:"VIN right" 2-0:"Right volume"
+}}
 
-The VIN mixing bits work exactly like bits in [`NR51`](<#FF25 — NR51: Sound panning>).
+- **VIN left/right**: These work exactly like the bits in [`NR51`](<#FF25 — NR51: Sound panning>). They should be set at 0 if external sound hardware is not being used.
+- **Left/right volume**: These specify the master volume, i.e. how much each output should be scaled.
 
-```
-Bit 7   - Mix VIN into left output  (1=Enable)
-Bit 6-4 - Left output volume        (0-7)
-Bit 3   - Mix VIN into right output (1=Enable)
-Bit 2-0 - Right output volume       (0-7)
-```
+  A value of 0 is treated as a volume of 1 (very quiet), and a value of 7 is treated as a volume of 8 (no volume reduction).
+  Importantly, the amplifier **never mutes** a non-silent input.
 
 ## Sound Channel 1 — Pulse with period sweep
 
@@ -119,11 +110,6 @@ For the same reason, the period sweep cannot underflow the period (which would t
 This register controls both the channel's [length timer](<#Length timer>) and [duty cycle](https://en.wikipedia.org/wiki/Duty_cycle) (the ratio of the time spent low vs. high).
 The selected duty cycle also alters the phase, although the effect is hardly noticeable except in combination with other channels.
 
-```
-Bit 7-6 - Wave duty            (Read/Write)
-Bit 5-0 - Initial length timer (Write Only)
-```
-
 <style>
 .waveform {
   display: block;
@@ -138,32 +124,42 @@ Bit 5-0 - Initial length timer (Write Only)
 }
 </style>
 
-Wave duty (binary) | Duty cycle | Waveform
-------------------:|:----------:|--------------------------
- 00                |   12.5 %   | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,0 35,0 35,10 40,10 40,0 75,0 75,10 80,10 80,0"/></svg>
- 01                |   25 %     | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,10 5,10 5,0 35,0 35,10 45,10 45,0 75,0 75,10 80,10"/></svg>
- 10                |   50 %     | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,10 5,10 5,0 25,0 25,10 45,10 45,0 65,0 65,10 80,10"/></svg>
- 11                |   75 %     | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,0 5,0 5,10 35,10 35,0 45,0 45,10 75,10 75,0 80,0"/></svg>
+{{#bits 8 >
+  "NR11"  7-6:"Wave duty" 5-0:"Initial length timer"
+}}
 
-It's worth noting that there is no audible difference between the 25 % and 75 % duty cycle settings.
+- **Duty cycle** (*Read/Write*): Controls the output waveform as follows:
 
-The higher the [length timer](<#Length timer>) field, the shorter the time before the channel is cut.
+  Value (binary) | Duty cycle | Waveform
+  --------------:|:----------:|--------------------------
+   00            |   12.5 %   | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,0 35,0 35,10 40,10 40,0 75,0 75,10 80,10 80,0"/></svg>
+   01            |   25 %     | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,10 5,10 5,0 35,0 35,10 45,10 45,0 75,0 75,10 80,10"/></svg>
+   10            |   50 %     | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,10 5,10 5,0 25,0 25,10 45,10 45,0 65,0 65,10 80,10"/></svg>
+   11            |   75 %     | <svg viewBox="0 -1 80 12" preserveAspectRatio="xMidYMid meet" class="waveform"><polyline points="0,0 5,0 5,10 35,10 35,0 45,0 45,10 75,10 75,0 80,0"/></svg>
+
+  It's worth noting that there is no audible difference between the 25 % and 75 % duty cycle settings.
+- **Initial length timer** (*Write-only*): The higher this field is, [the shorter the time before the channel is cut](<#Length timer>).
 
 ### FF12 — NR12: Channel 1 volume & envelope
 
 This register controls the digital amplitude of the "high" part of the pulse, and the sweep applied to that setting.
 
-```
-Bit 7-4 - Initial volume of envelope (0-F) (0=No Sound)
-Bit 3   - Envelope direction (0=Decrease, 1=Increase)
-Bit 2-0 - Sweep pace (0=No Sweep)
-```
+{{#bits 8 >
+  "NR12" 7-4:"Initial volume" 3:"Env dir" 2-0:"Sweep pace"
+}}
 
-Setting bits 3-7 of this register all to 0 turns the DAC off (and thus, the channel as well), which [may cause an audio pop](<#Mixer>).
+- **Initial volume**: How loud the channel initially is. Note that these bits are readable, but are **not** updated by the envelope functionality!
+- **Env dir**: The envelope's direction; `0` = decrease volume over time, `1` = increase volume over time.
+- **Sweep pace**: The envelope ticks at 64 Hz, and the channel's envelope will be increased / decreased (depending on bit 3) every <var>Sweep pace</var> of those ticks. A setting of 0 disables the envelope.
 
-The envelope ticks at 64 Hz, and the channel's envelope will be increased / decreased (depending on bit 3) every <var>Sweep pace</var> of those ticks.
+Setting bits 3-7 of this register all to 0 (initial volume = 0, envelope = decreasing) turns the DAC off (and thus, the channel as well), which [may cause an audio pop](<#Mixer>).
+
+::: warning
 
 Writes to this register while the channel is on require retriggering it afterwards.
+If the write turns the channel off, retriggering is not necessary (it would do nothing).
+
+:::
 
 ### FF13 — NR13: Channel 1 period low \[write-only\]
 
@@ -198,16 +194,13 @@ Period changes take
 
 ### FF14 — NR14: Channel 1 period high & control
 
-```
-Bit 7   - Trigger (1=Restart channel)  (Write Only)
-Bit 6   - Sound Length enable          (Read/Write)
-          (1=Stop output when length in NR11 expires)
-Bit 2-0 - Period value's higher 3 bits (Write Only)
-```
+{{#bits 8 >
+  "NR14" 7:"Trigger" 6:"Length enable" 2-0:"Period"
+}}
 
-Writing a value here with bit 7 set [triggers](<#Triggering>) the channel.
-
-Bit 6 takes effect immediately upon writing to this register.
+- **Trigger** (*Write-only*): Writing any value to `NR14` with this bit set [triggers](<#Triggering>) the channel.
+- **[Length](<#Length timer>) enable** (*Read/Write*): Takes effect immediately upon writing to this register.
+- **Period** (*Write-only*): The upper 3 bits of the period value; the lower 8 bits are stored in [`NR13`](<#FF13 — NR13: Channel 1 period low \[write-only\]>).
 
 ## Sound Channel 2 — Pulse
 
@@ -229,12 +222,12 @@ It's also possible to artificially "increase" the wave's length by loading a new
 
 ### FF1A — NR30: Channel 3 DAC enable
 
-This register controls CH3's DAC.
+This register controls CH3's [DAC](#DACs).
 Like other channels, turning the DAC off immediately turns the channel off as well.
 
-```
-Bit 7 - Sound Channel 3 DAC  (0=Off, 1=On)
-```
+{{#bits 8 >
+  "NR30" 7:"DAC on/off"
+}}
 
 The DAC is often turned off just before writing to [wave RAM](<#FF30–FF3F — Wave pattern RAM>) to avoid issues with accessing it; see further below for more info.
 
@@ -244,26 +237,28 @@ Turning the DAC off [may cause an audio pop](<#Mixer>).
 
 This register controls the channel's [length timer](<#Length timer>).
 
-```
-Bit 7-0 - length timer
-```
+{{#bits 8 >
+  "NR31" 7-0:"Initial length timer"
+}}
 
 The higher the [length timer](<#Length timer>), the shorter the time before the channel is cut.
 
 ### FF1C — NR32: Channel 3 output level
 
-This channel lacks the envelope functionality that the other three channels have.
+This channel lacks the envelope functionality that the other three channels have, and has a much coarser volume control.
 
-```
-Bits 6-5 - Output level selection
-```
+{{#bits 8 >
+  "NR32" 6-5:"Output level"
+}}
 
-Bits 6-5 (binary) | Output level
------------------:|--------------
-  %00             | Mute (No sound)
-  %01             | 100% volume (use samples read from Wave RAM as-is)
-  %10             |  50% volume (shift samples read from Wave RAM right once)
-  %11             |  25% volume (shift samples read from Wave RAM right twice)
+- **Output level**: Controls the channel's volume as follows:
+  
+  Bits 6-5 (binary) | Output level
+  -----------------:|--------------
+     00             | Mute (No sound)
+     01             | 100% volume (use samples read from Wave RAM as-is)
+     10             |  50% volume (shift samples read from Wave RAM right once)
+     11             |  25% volume (shift samples read from Wave RAM right twice)
 
 ### FF1D — NR33: Channel 3 period low \[write-only\]
 
@@ -292,28 +287,26 @@ Period changes (written to `NR33` or `NR34`) only take effect after the followin
 
 ### FF1E — NR34: Channel 3 period high & control
 
-```
-Bit 7   - Trigger (1=Restart Sound)    (Write Only)
-Bit 6   - Sound Length enable          (Read/Write)
-          (1=Stop output when length in NR31 expires)
-Bit 2-0 - Period value's higher 3 bits (Write Only)
-```
+{{#bits 8 >
+  "NR34" 7:"Trigger" 6:"Length enable" 2-0:"Period"
+}}
 
-Writing a value here with bit 7 set [triggers](<#Triggering>) the channel.
+- **Trigger** (*Write-only*): Writing any value to `NR14` with this bit set [triggers](<#Triggering>) the channel.
 
-::: warning RETRIGGERING CAUTION
+  ::: warning RETRIGGERING CAUTION
 
-On monochrome consoles only, retriggering CH3 while it's about to read a byte from wave RAM causes wave RAM to be corrupted in a generally unpredictable manner.
+  On monochrome consoles only, retriggering CH3 while it's about to read a byte from wave RAM causes wave RAM to be corrupted in a generally unpredictable manner.
 
-:::
+  :::
 
-Bit 6 takes effect immediately upon writing to this register.
+  ::: warning PLAYBACK DELAY
 
-::: warning PLAYBACK DELAY
+  Triggering the wave channel does not immediately start playing wave RAM; instead, the *last* sample ever read (which is reset to 0 when the APU is off) is output until the channel next reads a sample.
+  ([Source](https://github.com/LIJI32/SameSuite/blob/master/apu/channel_3/channel_3_delay.asm))
 
-Triggering the wave channel does not immediately start playing wave RAM; instead, the *last* sample ever read (which is reset to 0 when the APU is off) is output until the channel next reads a sample.
-
-:::
+  :::
+- **[Length](<#Length timer>) enable** (*Read/Write*): Takes effect immediately upon writing to this register.
+- **Period** (*Write-only*): The upper 3 bits of the period value; the lower 8 bits are stored in [`NR13`](<#FF13 — NR13: Channel 1 period low \[write-only\]>).
 
 ### FF30–FF3F — Wave pattern RAM
 
@@ -359,51 +352,44 @@ By default, the noise will sound close to white; but it can be manipulated to so
 
 This register controls the channel's [length timer](<#Length timer>).
 
-```
-Bit 5-0 - length timer
-```
+{{#bits 8 >
+  "NR41" 7-0:"Initial length timer"
+}}
 
 The higher the [length timer](<#Length timer>), the shorter the time before the channel is cut.
 
 ### FF21 — NR42: Channel 4 volume & envelope
 
-This register controls the digital amplitude produced when the LFSR outputs a 1, and the sweep applied to that setting.
-
-```
-Bit 7-4 - Initial volume of envelope (0-F) (0=No Sound)
-Bit 3   - Envelope direction (0=Decrease, 1=Increase)
-Bit 2-0 - Sweep pace (0=No Sweep)
-```
-
-Setting bits 3-7 of this register all to 0 turns the DAC off (and thus, the channel as well), which [may cause an audio pop](<#Mixer>).
-
-The envelope ticks at 64 Hz, and the channel's envelope will be increased / decreased (depending on bit 3) every <var>Sweep pace</var> of those ticks.
+This register functions exactly like [`NR12`](<#FF12 — NR12: Channel 1 volume & envelope>), so please refer to its documentation.
 
 ### FF22 — NR43: Channel 4 frequency & randomness
 
 This register allows controlling the way the amplitude is randomly switched.
 
-```
-Bit 7-4 - Clock shift (s)
-Bit 3   - LFSR width (0=15 bits, 1=7 bits)
-Bit 2-0 - Clock divider (r)
-```
+{{#bits 8 >
+  "NR43" 7-4:"Clock shift" 3:"LFSR width" 2-0:"Clock divider"
+}}
 
-The frequency at which the LFSR is clocked is <math><mfrac><mn>262144</mn><mrow><mi>r</mi><mo>×</mo><msup><mn>2</mn><mi>s</mi></msup></mrow></mfrac></math> Hz.
-(<var>r</var> = 0 is treated as <var>r</var> = 0.5 instead.)
+- **Clock shift**: See the frequency formula below.
+- **[LFSR](<#Noise channel (CH4)>) width**: `0` = 15-bit, `1` = 7-bit (more regular output; some frequencies sound more like pulse than noise).
+
+  ::: warning LFSR lockup
+
+  Switching from 15- to 7-bit mode when the LFSR [is in a certain state](<#Noise channel (CH4)>) can "lock it up", which essentially silences CH4; this can be avoided by retriggering CH4, which resets the LFSR.
+
+  :::
+- **Clock divider**: See the frequency formula below.
+  Note that <var>divider</var> = 0 is treated as <var>divider</var> = 0.5 instead.
+
+The frequency at which the LFSR is clocked is <math><mfrac><mn>262144</mn><mrow><mi>divider</mi><mo>×</mo><msup><mn>2</mn><mi>shift</mi></msup></mrow></mfrac></math> Hz.
+
 If the bit shifted out is a 0, the channel emits a 0; otherwise, it emits the volume selected in `NR42`.
-
-If the LFSR is set to 7-bit mode, the output will become more regular, and some frequencies will sound more like Pulse than Noise.
-Note that switching from 15- to 7-bit mode when the LFSR [is in a certain state](<#Noise channel (CH4)>) can "lock it up", which essentially silences CH4; this can be avoided by retriggering CH4, which resets the LFSR.
 
 ### FF23 — NR44: Channel 4 control
 
-```
-Bit 7   - Trigger (1=Restart channel)  (Write Only)
-Bit 6   - Sound Length enable          (Read/Write)
-          (1=Stop output when length in NR41 expires)
-```
+{{#bits 8 >
+  "NR44" 7:"Trigger" 6:"Length enable"
+}}
 
-Writing a value here with bit 7 set [triggers](<#Triggering>) the channel.
-
-Bit 6 takes effect immediately upon writing to this register.
+- **Trigger** (*Write-only*): Writing any value to `NR14` with this bit set [triggers](<#Triggering>) the channel.
+- **[Length](<#Length timer>) enable** (*Read/Write*): Takes effect immediately upon writing to this register.

--- a/src/Audio_Registers.md
+++ b/src/Audio_Registers.md
@@ -89,7 +89,7 @@ Bit 2-0 - Right output volume       (0-7)
 This register controls CH1's period sweep functionality.
 
 {{#bits 8 >
-  "NR10" 6-4:"Pace" 3:"Direction" 2-0:"Individual step";
+  "NR10"  6-4:"Pace" 3:"Direction" 2-0:"Individual step";
 }}
 
 - **Pace**: This dictates how often sweep "iterations" happen, in units of 128 Hz ticks[^div_apu] (7.8 ms).

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -139,10 +139,12 @@ loaded VRAM bank in bit 0, and all other bits will be set to 1.
 
 ### FF4D — KEY1 (CGB Mode only): Prepare speed switch
 
-```
- Bit 7: Current Speed     (0=Normal, 1=Double) (Read Only)
- Bit 0: Prepare Speed Switch (0=No, 1=Prepare) (Read/Write)
-```
+{{#bits 8 >
+   "KEY1" 7:"Current speed" 0:"Switch armed"
+}}
+
+- **Current speed** (*Read-only*): `0` = Single-speed mode, `1` = Double-speed mode
+- **Switch armed** (*Read/Write*): `0` = No, `1` = Armed
 
 This register is used to prepare the Game Boy to switch between CGB
 Double Speed Mode and Normal Speed Mode. The actual speed switch is
@@ -196,11 +198,13 @@ Bit 0 must be cleared — if you don't want to receive your own Game Boy's
 IR signal). After sending or receiving data you should reset the
 register to $00 to reduce battery power consumption again.
 
-```
- Bit 0:   Write Data   (0=LED Off, 1=LED On)             (Read/Write)
- Bit 1:   Read Data    (0=Receiving IR Signal, 1=Normal) (Read Only)
- Bit 6-7: Data Read Enable (0=Disable, 3=Enable)         (Read/Write)
-```
+{{#bits 8 >
+   "RP" 7-6:"Read enable" 1:"Receiving" 0:"Emitting"
+}}
+
+- **Read enable** (*Read/Write*): `0` = Disable (bit 1 reads `1`), `3` = Enable
+- **Receiving** (*Read-only*): `0` = Receiving IR signal, `1` = Normal
+- **Emitting** (*Read/Write*): `0` = LED off, `1` = LED on
 
 Note that the receiver will adapt itself to the normal level of IR
 pollution in the air, so if you would send a LED ON signal for a longer
@@ -225,22 +229,23 @@ It is not known if triggering a PSM NMI, which remaps the boot ROM, has an effec
 
 :::
 
-```
-Bit 0: OBJ Priority Mode (0=OAM Priority, 1=Coordinate Priority) (Read/Write)
-```
+{{#bits 8 >
+   "OPRI" 0:"Priority mode"
+}}
+
+- **Priority mode** (*Read/Write*): `0` = CGB-style priority, `1` = DMG-style priority
 
 ### FF70 — SVBK (CGB Mode only): WRAM bank
 
-In CGB Mode 32 KBytes internal RAM are available. This memory is divided
-into 8 banks of 4 KBytes each. Bank 0 is always available in memory at
-C000-CFFF, Bank 1-7 can be selected into the address space at D000-DFFF.
+In CGB Mode, 32 KiB of internal RAM are available.
+This memory is divided into 8 banks of 4 KiB each.
+Bank 0 is always available in memory at C000–CFFF, banks 1–7 can be selected into the address space at D000–DFFF.
 
-```
- Bit 0-2  Select WRAM Bank (Read/Write)
-```
+{{#bits 8 >
+"SVBK" 2-0:"WRAM bank"
+}}
 
-Writing a value of $01-$07 will select Bank 1-7, writing a value of $00
-will select Bank 1 too.
+- **WRAM bank** (*Read/Write*): Writing a value will map the corresponding bank to [D000–DFFF](<#Memory Map>), except 0, which maps bank 1 instead.
 
 ## Undocumented registers
 

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -91,7 +91,7 @@ $FFFF      | [IE]        | Interrupt enable                                     
 [NR44]: <#FF23 — NR44: Channel 4 control>
 [NR50]: <#FF24 — NR50: Master volume & VIN panning>
 [NR51]: <#FF25 — NR51: Sound panning>
-[NR52]: <#FF26 — NR52: Sound on/off>
+[NR52]: <#FF26 — NR52: Audio master control>
 [Wave RAM]: <#FF30–FF3F — Wave pattern RAM>
 [LCDC]: <#FF40 — LCDC: LCD control>
 [STAT]: <#FF41 — STAT: LCD status>

--- a/src/Joypad_Input.md
+++ b/src/Joypad_Input.md
@@ -6,16 +6,16 @@ The eight Game Boy action/direction buttons are arranged as a 2×4
 matrix. Select either action or direction buttons by writing to this
 register, then read out the bits 0-3.
 
-```
-Bit 7 - Not used
-Bit 6 - Not used
-Bit 5 - P15 Select Action buttons    (0=Select)
-Bit 4 - P14 Select Direction buttons (0=Select)
-Bit 3 - P13 Input: Down  or Start    (0=Pressed) (Read Only)
-Bit 2 - P12 Input: Up    or Select   (0=Pressed) (Read Only)
-Bit 1 - P11 Input: Left  or B        (0=Pressed) (Read Only)
-Bit 0 - P10 Input: Right or A        (0=Pressed) (Read Only)
-```
+{{#bits 8 >
+  "P1" 5:"Select buttons" 4:"Select d-pad" 3:"Start / Down" 2:"Select / Up" 1:"B / Left" 0:"A / Right"
+}}
+
+- **Select buttons**: If this bit is `0`, then buttons (SsBA) can be read from the lower nibble.
+- **Select d-pad**: If this bit is `0`, then directional keys can be read from the lower nibble.
+- The lower nibble is *Read-only*.
+  Note that, rather unconventionally for the Game Boy, a button being pressed is seen as the corresponding bit being **`0`**, not `1`.
+  
+  If neither buttons nor d-pad is selected (`$30` was written), then the low nibble reads `$F` (all buttons released).
 
 ::: tip NOTE
 

--- a/src/LCDC.md
+++ b/src/LCDC.md
@@ -5,16 +5,19 @@
 **LCDC** is the main **LCD C**ontrol register. Its bits toggle what
 elements are displayed on the screen, and how.
 
-Bit | Name                           | Usage notes
-----|--------------------------------|-------------------------
- 7  | LCD and PPU enable             | 0=Off, 1=On
- 6  | Window tile map area           | 0=9800-9BFF, 1=9C00-9FFF
- 5  | Window enable                  | 0=Off, 1=On
- 4  | BG and Window tile data area   | 0=8800-97FF, 1=8000-8FFF
- 3  | BG tile map area               | 0=9800-9BFF, 1=9C00-9FFF
- 2  | OBJ size                       | 0=8×8, 1=8×16
- 1  | OBJ enable                     | 0=Off, 1=On
- 0  | BG and Window enable/priority  | 0=Off, 1=On
+{{#bits 8 >
+  "" 7:"LCD & PPU enable" 6:"Window tile map" 5:"Window enable" 4:"BG & Window tiles"
+     3:"BG tile map" 2:"OBJ size" 1:"OBJ enable" 0:"BG & Window enable / priority";
+}}
+
+- **[LCD & PPU enable](<#LCDC.7 — LCD enable>)**: `0` = Off; `1` = On
+- **[Window tile map area](<#LCDC.6 — Window tile map area>)**: `0` = 9800–9BFF; `1` = 9C00–9FFF
+- **[Window enable](<#LCDC.5 — Window enable>)**: `0` = Off; `1` = On
+- **[BG & Window tile data area](<#LCDC.4 — BG and Window tile data area>)**: `0` = 8800–97FF; `1` = 8000–8FFF
+- **[BG tile map area](<#LCDC.3 — BG tile map area>)**: `0` = 9800–9BFF; `1` = 9C00–9FFF
+- **[OBJ size](<#LCDC.2 — OBJ size>)**: `0` = 8×8; `1` = 8×16
+- **[OBJ enable](<#LCDC.1 — OBJ enable>)**: `0` = Off; `1` = On
+- **[BG & Window enable / priority](<#LCDC.0 — BG and Window enable/priority>)** *\[Different meaning in CGB Mode\]*: `0` = Off; `1` = On
 
 ### LCDC.7 — LCD enable
 
@@ -73,7 +76,6 @@ Objects (sprites) aren't affected by this, and will always use the \$8000 addres
 This bit works similarly to [LCDC bit 6](<#LCDC.6 — Window tile map area>):
 if the bit is clear (0), the BG uses tilemap $9800, otherwise tilemap $9C00.
 
-
 ### LCDC.2 — OBJ size
 
 This bit controls the size of all objects (1 tile or 2 stacked vertically).
@@ -128,8 +130,8 @@ A problem often seen in 8-bit games is objects rendering on top
 of the textbox/status bar. It's possible to prevent this using LCDC if
 the textbox/status bar is "alone" on its scanlines:
 
--   Set LCDC.1 to 1 for gameplay scanlines
--   Set LCDC.1 to 0 for textbox/status bar scanlines
+- Set LCDC.1 to 1 for gameplay scanlines
+- Set LCDC.1 to 0 for textbox/status bar scanlines
 
 Usually, these bars are either at the top or bottom of the screen, so
 the bit can be set by the VBlank and/or STAT handlers.

--- a/src/LCDC.md
+++ b/src/LCDC.md
@@ -6,8 +6,8 @@
 elements are displayed on the screen, and how.
 
 {{#bits 8 >
-  "" 7:"LCD & PPU enable" 6:"Window tile map" 5:"Window enable" 4:"BG & Window tiles"
-     3:"BG tile map" 2:"OBJ size" 1:"OBJ enable" 0:"BG & Window enable / priority";
+  ""  7:"LCD & PPU enable" 6:"Window tile map" 5:"Window enable" 4:"BG & Window tiles"
+      3:"BG tile map" 2:"OBJ size" 1:"OBJ enable" 0:"BG & Window enable / priority";
 }}
 
 - **[LCD & PPU enable](<#LCDC.7 — LCD enable>)**: `0` = Off; `1` = On

--- a/src/MBC1.md
+++ b/src/MBC1.md
@@ -46,14 +46,9 @@ All of the MBC1 registers default to $00 on power-up, which for the "ROM Bank Nu
 ### 0000–1FFF — RAM Enable (Write Only)
 
 Before external RAM can be read or written, it must be enabled by
-writing $A to this address space.
-Any value with $A in the lower 4 bits enables the RAM attached to the MBC and any
-other value disables the RAM. It is unknown why $A is the value used to enable RAM.
-
-```
-$00  Disable RAM (default)
-$0A  Enable RAM
-```
+writing `$A` to anywhere in this address space.
+Any value with `$A` in the lower 4 bits **enables** the RAM attached to the MBC, and any
+other value **disables** the RAM. It is unknown why `$A` is the value used to enable RAM.
 
 It is recommended to disable external RAM
 after accessing it, in order to protect its contents from corruption during
@@ -80,14 +75,14 @@ register at 4000–5FFF is used to supply an additional 2 bits for the
 effective bank number:
 `Selected ROM Bank = (Secondary Bank << 5) + ROM Bank`.[^MBC1M_banking]
 
-[^MBC1M_banking]: MBC1M has a different formula, see below
-
 These additional two bits are ignored for the bank 00→01 translation. This causes a problem — attempting to access banks $20, $40, and $60 only set bits in the upper 2-bit register, with the lower 5-bit register set to 00. As a result, any
 attempt to address these ROM Banks will select Bank $21, $41 and $61
 instead. The only way to access banks $20, $40 or $60 at all is to enter mode 1,
 which remaps the 0000–3FFF range. This has its own problems for game
 developers as that range contains interrupt handlers, so it's usually only
 used in multi-game compilation carts (see below).
+
+[^MBC1M_banking]: MBC1M has a different formula, see below.
 
 ### 4000–5FFF — RAM Bank Number — or — Upper Bits of ROM Bank Number (Write Only)
 

--- a/src/MBC1.md
+++ b/src/MBC1.md
@@ -99,16 +99,20 @@ applied to bits 4-5 of the ROM bank number and the top bit of the main
 
 This 1-bit register selects between the two MBC1 banking modes, controlling
 the behaviour of the secondary 2-bit banking register (above). If the cart
-is not large enough to use the 2-bit register (<= 8 KiB RAM and <= 512 KiB ROM)
+is not large enough to use the 2-bit register (≤ 8 KiB RAM and ≤ 512 KiB ROM)
 this mode select has no observable effect. The program may freely switch
 between the two modes at any time.
 
-```
-00 = Simple Banking Mode (default)
-     0000–3FFF and A000–BFFF locked to bank 0 of ROM/RAM
-01 = RAM Banking Mode / Advanced ROM Banking Mode
-     0000–3FFF and A000–BFFF can be bank-switched via the 4000–5FFF bank register
-```
+{{#bits 8 >
+  "Value written" 0:"Banking mode"
+}}
+
+The **banking mode** can be:
+- `0` = *simple* (default): 0000–3FFF and A000–BFFF are locked to bank 0 of ROM and SRAM respectively.
+- `1` = *advanced*: 0000–3FFF and A000-BFFF can be bank-switched via the [4000–5FFF register](<#4000–5FFF — RAM Bank Number — or — Upper Bits of ROM Bank Number (Write Only)>).
+
+
+::: tip
 
 Technically, the MBC1 has AND gates between the both bank registers and the second-highest bit of the address. This is intended to cause accesses to the 0000–3FFF region (which has that address bit set to 0) to treat both registers as always 0, so that only bank 0 is accessible through this address.
 
@@ -116,68 +120,48 @@ However, when the second bank register is connected to RAM, this has the side ef
 
 Setting the mode to 1 disables these AND gates, allowing the two-bit register to switch the selected bank in both these regions.
 
+:::
+
 ## Addressing diagrams
 
 The following diagrams show how the address within the ROM/RAM chips are calculated from the accessed address and banking registers
 
 ### 0000–3FFF
 
-In mode 0:
-
-```
-Bits: 20 19 18 17 16 15 14 13 12 .. 01 00
-      \___/ \____________/ \____________/
-        |          |            \----------- From Game Boy address
-        |          \------------------------ Always 0
-        \----------------------------------- Always 0
-```
-
-In mode 1:
-
-```
-Bits: 20 19 18 17 16 15 14 13 12 .. 01 00
-      \___/ \____________/ \____________/
-        |          |            \----------- From Game Boy address
-        |          \------------------------ Always 0
-        \----------------------------------- As 4000–5FFF bank register
-```
+<div class=table-wrapper><table class=bit-descrs><thead><tr>
+  <th></th><th>20</th><th>19</th><th>18</th><th>17</th><th>16</th><th>15</th><th>14</th><th>13</th><th>12</th><th>...</th><th>1</th><th>0</th>
+</tr></thead><tbody><tr>
+  <td><strong>Mode 0</strong></td><td colspan=2>0</td><td rowspan=2 colspan=5>0</td><td rowspan=2 colspan=5>From Game Boy address</td>
+</tr><tr>
+  <td><strong>Mode 1</strong></td><td colspan=2>From 4000–5FFF bank register</td>
+</tr></tbody></table></div>
 
 ### 4000–7FFF
 
-Regardless of mode:
+<div class=table-wrapper><table class=bit-descrs><thead><tr>
+  <th></th><th>20</th><th>19</th><th>18</th><th>17</th><th>16</th><th>15</th><th>14</th><th>13</th><th>12</th><th>...</th><th>1</th><th>0</th>
+</tr></thead><tbody><tr>
+  <td><strong>Mode 0 / Mode 1</strong></td><td colspan=2>From 4000–5FFF bank register</td><td colspan=5>From 2000–3FFF bank register</td><td colspan=5>From Game Boy address</td>
+</tr></tbody></table></div>
 
-```
-                              /------------- In a smaller cart, only the needed
-                              |              bits are used (e.g 128kiB uses 17)
-                  /---------------------\
-Bits: 20 19 18 17 16 15 14 13 12 .. 01 00
-      \___/ \____________/ \____________/
-        |          |            \----------- From Game Boy address
-        |          \------------------------ As 2000–3FFF bank register
-        \----------------------------------- As 4000–5FFF bank register
-```
+::: tip
+
+In a smaller cartridge, some of the upper bits are ignored.
+(For example, a 128 KiB = 2<sup>17</sup> bytes ROM only uses bits 0–16.)
+
+:::
 
 ### A000–BFFF
 
-In mode 0:
+<div class=table-wrapper><table class=bit-descrs><thead><tr>
+  <th></th><th>14</th><th>13</th><th>12</th><th>...</th><th>1</th><th>0</th>
+</tr></thead><tbody><tr>
+  <td><strong>Mode 0</strong></td><td colspan=2>0</td><td rowspan=2 colspan=4>From Game Boy address</td>
+</tr><tr>
+  <td><strong>Mode 1</strong></td><td colspan=2>From 4000–5FFF bank register</td>
+</tr></tbody></table></div>
 
-```
-Bits: 14 13 12 .. 01 00
-      \___/ \_________/
-        |        \-------- From Game Boy address
-        \----------------- Always 0
-```
-
-In mode 1:
-
-```
-Bits: 14 13 12 .. 01 00
-      \___/ \_________/
-        |        \-------- From Game Boy address
-        \----------------- As 4000–5FFF bank register
-```
-
-## "MBC1M" 1 MiB Multi-Game Compilation Carts
+## "MBC1M": 1 MiB Multi-Game Compilation Carts
 
 Known as MBC1M, these carts have an alternative wiring, that ignores
 the top bit of the main ROM banking register (making it effectively a 4-bit register for banking, though the full 5 bit register is still used for 00→01 translation)
@@ -203,29 +187,22 @@ by increasing the ROM size to 2 MiB and duplicating each sub-ROM — $00–$0F
 duplicated into $10-$1F, the original $10-$1F placed in $20-$2F and
 duplicated into $30-$3F and so on.
 
-## MBC1M addressing diagrams:
+### MBC1M addressing diagrams
 
-### 0000–3FFF
+#### 0000–3FFF
 
-(In mode 1)
+<div class=table-wrapper><table class=bit-descrs><thead><tr>
+  <th></th><th>19</th><th>18</th><th>17</th><th>16</th><th>15</th><th>14</th><th>13</th><th>12</th><th>..</th><th>1</th><th>0</th>
+</tr></thead><tbody><tr>
+  <td><strong>Mode 0</strong></td><td colspan=2>0</td><td colspan=4>0</td><td rowspan=2 colspan=5>From Game Boy address</td>
+</tr><tr>
+  <td><strong>Mode 1</strong></td><td colspan=2>From 4000–5FFF bank register</td><td colspan=4>From 2000–3FFF bank register (bit 4 unused)</td>
+</tr></tbody></table></div>
 
-```
-Bits: 19 18    17 16 15 14 13 12 .. 01 00
-      \___/ \____________/ \____________/
-        |          |            \----------- From Game Boy address
-        |          \------------------------ Always 0
-        \----------------------------------- As 4000–5FFF bank register
-```
+#### 4000–7FFF
 
-### 4000–7FFF
-
-Regardless of mode:
-
-```
-Bits: 19 18    17 16 15 14 13 12 .. 01 00
-      \___/ \____________/ \____________/
-        |          |            \----------- From Game Boy address
-        |          \------------------------ As 2000–3FFF bank register
-        |                                       (only 4 bits used)
-        \----------------------------------- As 4000–5FFF bank register
-```
+<div class=table-wrapper><table class=bit-descrs><thead><tr>
+  <th></th><th>19</th><th>18</th><th>17</th><th>16</th><th>15</th><th>14</th><th>13</th><th>12</th><th>..</th><th>1</th><th>0</th>
+</tr></thead><tbody><tr>
+  <td><strong>Mode 0 / Mode 1</strong></td><td colspan=2>From 4000–5FFF bank register</td><td colspan=4>From 2000–3FFF bank register (bit 4 unused)</td><td colspan=5>From Game Boy address</td>
+</tr></tbody></table></div>

--- a/src/OAM.md
+++ b/src/OAM.md
@@ -49,16 +49,16 @@ tile is "NN & \$FE", and the bottom 8×8 tile is "NN | \$01".
 
 ## Byte 3 — Attributes/Flags
 
-{{#bits 8
+{{#bits 8 >
   "Attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 4:"DMG palette" 3:"Bank" 2-0:"CGB palette";
 }}
 
-- **Priority**: `0` = No, `1` = BG and Window colors 1-3 over this OBJ
+- **Priority**: `0` = No, `1` = BG and Window colors 1–3 are drawn over this OBJ
 - **Y flip**: `0` = Normal, `1` = Entire OBJ is vertically mirrored
 - **X flip**: `0` = Normal, `1` = Entire OBJ is horizontally mirrored
 - **DMG palette** *\[Non CGB Mode only\]*: `0` = OBP0, `1` = OBP1
-- **Bank** *\[CGB Mode Only\]*: `0` = Fetch tile in VRAM bank 0, `1` = Fetch tile in VRAM bank 1
-- **CGB palette** *\[CGB Mode Only\]*: Use OBP0-7
+- **Bank** *\[CGB Mode Only\]*: `0` = Fetch tile from VRAM bank 0, `1` = Fetch tile from VRAM bank 1
+- **CGB palette** *\[CGB Mode Only\]*: Which of OBP0–7 to use
 
 ## Writing data to OAM
 
@@ -110,7 +110,7 @@ differently when in CGB mode.
 
 ::: tip Interaction with "BG over OBJ" flag
 
-Object drawing priority and "BG over OBJ" interact in a non-intuitive way.
+Object drawing priority and ["BG over OBJ"](<#BG Map Attributes (CGB Mode only)>) interact in a non-intuitive way.
 
 Internally, the PPU first resolves priority between objects to
 pick an "object pixel", which is the first non-transparent pixel encountered

--- a/src/OAM.md
+++ b/src/OAM.md
@@ -49,14 +49,16 @@ tile is "NN & \$FE", and the bottom 8×8 tile is "NN | \$01".
 
 ## Byte 3 — Attributes/Flags
 
-```
- Bit7   BG and Window over OBJ (0=No, 1=BG and Window colors 1-3 over the OBJ)
- Bit6   Y flip          (0=Normal, 1=Vertically mirrored)
- Bit5   X flip          (0=Normal, 1=Horizontally mirrored)
- Bit4   Palette number  **Non CGB Mode Only** (0=OBP0, 1=OBP1)
- Bit3   Tile VRAM-Bank  **CGB Mode Only**     (0=Bank 0, 1=Bank 1)
- Bit2-0 Palette number  **CGB Mode Only**     (OBP0-7)
-```
+{{#bits 8
+  "Attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 4:"DMG palette" 3:"Bank" 2-0:"CGB palette";
+}}
+
+- **Priority**: `0` = No, `1` = BG and Window colors 1-3 over this OBJ
+- **Y flip**: `0` = Normal, `1` = Entire OBJ is vertically mirrored
+- **X flip**: `0` = Normal, `1` = Entire OBJ is horizontally mirrored
+- **DMG palette** *\[Non CGB Mode only\]*: `0` = OBP0, `1` = OBP1
+- **Bank** *\[CGB Mode Only\]*: `0` = Fetch tile in VRAM bank 0, `1` = Fetch tile in VRAM bank 1
+- **CGB palette** *\[CGB Mode Only\]*: Use OBP0-7
 
 ## Writing data to OAM
 

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -5,15 +5,13 @@
 
 ### FF47 — BGP (Non-CGB Mode only): BG palette data
 
-This register assigns gray shades to the color indexes of the BG and
-Window tiles.
+This register assigns gray shades to the [color IDs](./Tile_Data.md) of the BG and Window tiles.
 
-```
-Bit 7-6 - Color for index 3
-Bit 5-4 - Color for index 2
-Bit 3-2 - Color for index 1
-Bit 1-0 - Color for index 0
-```
+{{#bits 8 >
+  "Color for..." 7-6:"ID 3" 5-4:"ID 2" 3-2:"ID 1" 1-0:"ID 0";
+}}
+
+Each of the two-bit values map to a color thusly:
 
 Value | Color
 ------|-------
@@ -28,7 +26,7 @@ instead.
 ### FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data
 
 These registers assigns gray shades to the color indexes of the OBJs that use the corresponding palette.
-They work exactly like BGP, except that the lower two bits are ignored because color index 0 is transparent for OBJs.
+They work exactly like [`BGP`](<#FF47 — BGP (Non-CGB Mode only): BG palette data>), except that the lower two bits are ignored because color index 0 is transparent for OBJs.
 
 ## LCD Color Palettes (CGB only)
 
@@ -42,34 +40,31 @@ This register is used to address a byte in the CGB's background palette RAM.
 Since there are 8 palettes, 8 palettes × 4 colors/palette × 2 bytes/color = 64 bytes
 can be addressed.
 
-```
-Bit 7     Auto Increment  (0=Disabled, 1=Increment after Writing)
-Bit 5-0   Address ($00-3F)
-```
-
 First comes BGP0 color number 0, then BGP0 color number 1, BGP0 color number 2, BGP0 color number 3,
 BGP1 color number 0, and so on. Thus, address $03 allows accessing the second (upper)
 byte of BGP0 color #1 via BCPD, which contains the color's blue and upper green bits.
 
-data can be read from or written to the specified CRAM address through
-BCPD/BGPD. If the Auto Increment bit is set, the index gets
-incremented after each **write** to BCPD. Auto Increment has
-no effect when **reading** from BCPD, so the index must be manually
-incremented in that case. Writing to BCPD during rendering still causes
-auto-increment to occur, despite the write being blocked.
+{{#bits 8 >
+  "BCPS / OCPS" 7:"Auto-increment" 5-0:"Address";
+}}
+
+- **Auto-increment**: `0` = Disabled; `1` = Increment "Address" field after **writing** to
+  [`BCPD`](<#FF69 — BCPD/BGPD (CGB Mode only): Background color palette data / Background palette data>) /
+  [`OCPD`](<#FF6A–FF6B — OCPS/OBPI, OCPD/OBPD (CGB Mode only): OBJ color palette specification / OBJ palette index, OBJ color palette data / OBJ palette data>)
+  (even during [Mode 3](<#PPU modes>), despite the write itself failing), reads *never* cause an increment
+- **Address**: Specifies which byte of BG Palette Memory can be accessed through
+  [`BCPD`](<#FF69 — BCPD/BGPD (CGB Mode only): Background color palette data / Background palette data>)
 
 Unlike BCPD, this register can be accessed outside VBlank and HBlank.
 
 ### FF69 — BCPD/BGPD (CGB Mode only): Background color palette data / Background palette data
 
-This register allows to read/write data to the CGBs background palette memory,
-addressed through BCPS/BGPI. Each color is stored as little-endian RGB555:
+This register allows to read/write data to the CGBs background palette memory, addressed through [BCPS/BGPI](<#FF68 — BCPS/BGPI (CGB Mode only): Background color palette specification / Background palette index>).
+Each color is stored as little-endian RGB555:
 
-```
-Bit 0-4   Red Intensity   ($00-1F)
-Bit 5-9   Green Intensity ($00-1F)
-Bit 10-14 Blue Intensity  ($00-1F)
-```
+{{#bits 16 <
+  "One color" 0-4:"Red intensity" 5-9:"Green intensity" 10-14:"Blue intensity";
+}}
 
 Much like VRAM, data in palette memory cannot be read or written during the time
 when the PPU is reading from it, that is, [Mode 3](<#PPU modes>).

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -8,7 +8,7 @@
 This register assigns gray shades to the [color IDs](./Tile_Data.md) of the BG and Window tiles.
 
 {{#bits 8 >
-  "Color for..." 7-6:"ID 3" 5-4:"ID 2" 3-2:"ID 1" 1-0:"ID 0";
+  "Color for..."  7-6:"ID 3" 5-4:"ID 2" 3-2:"ID 1" 1-0:"ID 0";
 }}
 
 Each of the two-bit values map to a color thusly:
@@ -45,7 +45,7 @@ BGP1 color number 0, and so on. Thus, address $03 allows accessing the second (u
 byte of BGP0 color #1 via BCPD, which contains the color's blue and upper green bits.
 
 {{#bits 8 >
-  "BCPS / OCPS" 7:"Auto-increment" 5-0:"Address";
+  "BCPS / OCPS"  7:"Auto-increment" 5-0:"Address";
 }}
 
 - **Auto-increment**: `0` = Disabled; `1` = Increment "Address" field after **writing** to
@@ -63,7 +63,7 @@ This register allows to read/write data to the CGBs background palette memory, a
 Each color is stored as little-endian RGB555:
 
 {{#bits 16 <
-  "One color" 0-4:"Red intensity" 5-9:"Green intensity" 10-14:"Blue intensity";
+  "One color"  0-4:"Red intensity" 5-9:"Green intensity" 10-14:"Blue intensity";
 }}
 
 Much like VRAM, data in palette memory cannot be read or written during the time

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -373,7 +373,7 @@ The table above was obtained from Mooneye-GB tests [`acceptance/boot_hwio-dmg0`]
 [`NR44`]: <#FF23 — NR44: Channel 4 control>
 [`NR50`]: <#FF24 — NR50: Master volume & VIN panning>
 [`NR51`]: <#FF25 — NR51: Sound panning>
-[`NR52`]: <#FF26 — NR52: Sound on/off>
+[`NR52`]: <#FF26 — NR52: Audio master control>
 [`LCDC`]: <#FF40 — LCDC: LCD control>
 [`STAT`]: <#FF41 — STAT: LCD status>
 [`SCY`]: <#FF42–FF43 — SCY, SCX: Viewport Y position, X position>

--- a/src/SGB_Color_Palettes.md
+++ b/src/SGB_Color_Palettes.md
@@ -12,16 +12,22 @@ these palettes are used. Palettes 4-7 are used for the SGB Border, all
 
 Colors are encoded as 16-bit RGB numbers, in the following way:
 
-```
-FEDC BA98 7654 3210
-0BBB BBGG GGGR RRRR
-```
+{{#bits 16 >
+  "" 15:"Ignored" 14-10:"Blue" 9-5:"Green" 4-0:"Red"
+}}
+
+The palettes are encoded **little-endian**, thus, the Red+Green byte comes
+first in memory.
+
+::: tip
+
+This is the same format as [Game Boy Color palettes](<#LCD Color Palettes (CGB only)>).
+However, the same color will be displayed differently by SGB and CGB due to the different screen gamma!
+
+:::
 
 Here's a formula to convert 24-bit RGB into SNES format:
 `(color & 0xF8) << 7 | (color & 0xF800) >> 6 | (color & 0xF80000) >> 19`
-
-The palettes are encoded **little-endian**, thus, the R/G byte comes
-first in memory.
 
 ## Color 0 Restriction
 
@@ -39,12 +45,12 @@ Because the SGB/SNES reads out the Game Boy video controllers display
 signal, it translates the different grayshades from the signal into SNES
 colors as such:
 
-```
-White       -->  Color #0
-Light Gray  -->  Color #1
-Dark Gray   -->  Color #2
-Black       -->  Color #3
-```
+GB color   | SNES palette **index**
+-----------|-----------------------
+White      | Color #0
+Light gray | Color #1
+Dark gray  | Color #2
+Black      | Color #3
 
 Note that Game Boy colors 0-3 are assigned to user-selectable grayshades
 by the Game Boy's BGP, OBP0, and OBP1 registers. There is thus no fixed
@@ -53,7 +59,7 @@ relationship between Game Boy colors 0-3 and SNES colors 0-3.
 ### Using Game Boy BGP/OBP Registers
 
 A direct translation of GB color 0-3 into SNES color 0-3 may be produced
-by setting BGP/OBPx registers to a value of $0E4 each. However, in case
+by setting BGP/OBPx registers to a value of $E4 each. However, in case
 that your program uses black background for example, then you may
 internally assign background as "White" at the Game Boy side by BGP/OBP
 registers (which is then interpreted as SNES color 0, which is shared

--- a/src/SGB_Command_Packet.md
+++ b/src/SGB_Command_Packet.md
@@ -22,6 +22,7 @@ Time   0         50       100       150
 [The boot ROM](<#Super Game Boy (SGB, SGB2)>) and licensed software keep data and reset pulses LOW for at least 5 μs and leave P14 and P15 HIGH for at least 15 μs after each pulse.
 Though the hardware is capable of receiving pulses and spaces as short as 2 μs (as tested using [sgb-speedtest]),
 following the common practice of 5-cycle pulses and 15-cycle spaces may improve reliability in some corner case that the community has not yet discovered.
+
 Obviously, it'd be no good idea to access [the joypad register](<#FF00 — P1/JOYP: Joypad>) during the transfer,
 for example, in case that your VBlank interrupt procedure reads-out
 joypad states each frame, so be sure to disable that interrupt during the
@@ -56,3 +57,10 @@ By using all 7 packets, up to 111 data bytes (15+16\*6) may be sent.
 Unused bytes at the end of the last packet don't matter.
 The GB program should wait 60 ms (4 frames) between each packet transfer and the next,
 as the "bomb" tool to erase a user-drawn border can cause the SGB system software not to check for packets for 4 frames.
+
+::: tip
+
+Bytes with no indicated purpose are simply ignored by the SGB BIOS.
+They can be set to any value (but they must still be transferred).
+
+:::

--- a/src/SGB_Command_Palettes.md
+++ b/src/SGB_Command_Palettes.md
@@ -5,96 +5,111 @@
 Transmit color data for SGB palette 0, color 0-3, and for SGB palette 1,
 color 1-3 (without separate color 0).
 
-```
- Byte  Content
- 0     Command*8+Length (fixed length=$01)
- 1-E   Color Data for 7 colors of 2 bytes (16 bits) each:
-         Bit 0-4   - Red Intensity   (0-31)
-         Bit 5-9   - Green Intensity (0-31)
-         Bit 10-14 - Blue Intensity  (0-31)
-         Bit 15    - Not used (zero)
- F     Not used ($00)
-```
+{{#bits 16 <
+        "" 0:"Header"
+           1-2:"Pals 0 & 1 color #0"
+            3-4:"Pal 0 color #1"   5-6:"Pal 0 color #2"   7-8:"Pal 0 color #3"
+           9-10:"Pal 1 color #1" 11-12:"Pal 1 color #2" 13-14:"Pal 1 color #3"
+}}
 
-This is the same RGB5 format as [Game Boy Color palette
-entry](<#LCD Color Palettes (CGB only)>), though
-without the LCD correction. The value transferred as color 0 will be
-applied for all four palettes.
+The **header** byte is `$00 << 3 | $01` = $01.
 
 ## SGB Command $01 — PAL23
 
-Same as above PAL01, but for Palettes 2 and 3 respectively.
+Same as `PAL01` above, but for Palettes 2 and 3 respectively.
+The **header** byte is thus $09.
 
 ## SGB Command $02 — PAL03
 
-Same as above PAL01, but for Palettes 0 and 3 respectively.
+Same as `PAL01` above, but for Palettes 0 and 3 respectively.
+The **header** byte is thus $11.
 
 ## SGB Command $03 — PAL12
 
-Same as above PAL01, but for Palettes 1 and 2 respectively.
+Same as `PAL01` above, but for Palettes 1 and 2 respectively.
+The **header** byte is thus $19.
 
 ## SGB Command $0A — PAL_SET
 
 Used to copy pre-defined palette data from SGB system color palettes to
 actual SNES palettes.
 
-Note: all palette numbers are little-endian.
+::: warning
 
-```
- Byte  Content
- 0     Command*8+Length (fixed length=1)
- 1-2   System Palette number for SGB Color Palette 0 (0-511)
- 3-4   System Palette number for SGB Color Palette 1 (0-511)
- 5-6   System Palette number for SGB Color Palette 2 (0-511)
- 7-8   System Palette number for SGB Color Palette 3 (0-511)
- 9     Attribute File
-         Bit 0-5 - Attribute File Number ($00-$2C) (Used only if Bit7=1)
-         Bit 6   - Cancel Mask           (0=No change, 1=Yes)
-         Bit 7   - Use Attribute File    (0=No, 1=Apply above ATF Number)
- A-F   Not used (zero)
-```
+Before using this feature, System Palette data should be initialized by
+[`PAL_TRN`](<#SGB Command $0B — PAL_TRN>) command, and (when used) Attribute File (ATF) data should be
+initialized by [`ATTR_TRN`](<#SGB Command $15 — ATTR_TRN>).
 
-Before using this function, System Palette data should be initialized by
-PAL_TRN command, and (when used) Attribute File data should be
-initialized by ATTR_TRN.
+:::
+
+{{#bits 16 <
+        "" 0:"Header"
+           1-2:"Palette #0's ID"
+           3-4:"Palette #1's ID"
+           5-6:"Palette #2's ID"
+           7-8:"Palette #3's ID"
+           9:"Flags"
+}}
+
+The **header** byte is `$0A << 3 | $01` = $51.
+All **palette ID**s are little-endian.
+
+{{#bits 8 >
+        "Flags" 7:"Apply ATF" 6:"Cancel MASK_EN" 5-0:"ATF number"
+}}
+
+- **Apply ATF**: If and only if this is set, then the ATF whose ID is specified by bits 0–5 is applied as if by [`ATTR_SET`](<#SGB Command $16 — ATTR_SET>).
+- **Cancel `MASK_EN`**: If this bit is set, then any current [`MASK_EN`](<#SGB Command $17 — MASK_EN>) "screen freeze" is cancelled.
+- **ATF number**: Index of the ATF to transfer. Values greater than $2C are invalid.
 
 ## SGB Command $0B — PAL_TRN
 
 Used to initialize SGB system color palettes in SNES RAM. System color
 palette memory contains 512 pre-defined palettes, these palettes do not
-directly affect the display, however, the PAL_SET command may be later
+directly affect the display, however, the `PAL_SET` command may be later
 used to transfer four of these "logical" palettes to actual visible
-"physical" SGB palettes. Also, the OBJ_TRN function will use groups
+"physical" SGB palettes. Also, the `OBJ_TRN` feature will use groups
 of 4 System Color Palettes (4\*4 colors) for SNES OBJ palettes (16
 colors).
 
-```
- Byte  Content
- 0     Command*8+Length (fixed length=1)
- 1-F   Not used (zero)
-```
+{{#bits 16 <
+        "" 0:"Header"
+}}
 
-The palette data is sent by VRAM-Transfer (4 KBytes).
+The **header** byte must be $59.
 
-```
- 000-FFF  Data for System Color Palette 0-511
-```
+The palette data is sent by [VRAM Transfer](<#VRAM Transfers>).
 
-Each Palette consists of four 16-bit color definitions (8 bytes). Note:
+<div class=table-wrapper><table class=bit-descrs><thead><tr>
+        <th></th><th>…0</th><th>…1</th><th>…2</th><th>…3</th><th>…4</th><th>…5</th><th>…6</th><th>…7</th><th>…8</th><th>…9</th><th>…A</th><th>…B</th><th>…C</th><th>…D</th><th>…E</th><th>…F</th>
+</tr></thead><tbody><tr>
+        <td>$800…</td><td colspan=2>Pal #0 color #0</td><td colspan=2>Pal #0 color #1</td><td colspan=2>Pal #0 color #2</td><td colspan=2>Pal #0 color #3</td><td colspan=2>Pal #1 color #0</td><td colspan=2>Pal #1 color #1</td><td colspan=2>Pal #1 color #2</td><td colspan=2>Pal #1 color #3</td>
+</tr><tr>
+        <td>$801…</td><td colspan=2>Pal #2 color #0</td><td colspan=2>Pal #2 color #1</td><td colspan=2>Pal #2 color #2</td><td colspan=2>Pal #2 color #3</td><td colspan=2>Pal #3 color #0</td><td colspan=2>Pal #3 color #1</td><td colspan=2>Pal #3 color #2</td><td colspan=2>Pal #3 color #3</td>
+</tr><tr>
+        <td>…</td><td colspan=16>…</td>
+</tr><tr>
+        <td>$8FF…</td><td colspan=2>Pal #510 color #0</td><td colspan=2>Pal #510 color #1</td><td colspan=2>Pal #510 color #2</td><td colspan=2>Pal #510 color #3</td><td colspan=2>Pal #511 color #0</td><td colspan=2>Pal #511 color #1</td><td colspan=2>Pal #511 color #2</td><td colspan=2>Pal #511 color #3</td>
+</tr></tbody></table></div>
+
+::: tip
+
 The data is stored at 3000-3FFF in SNES memory.
+
+:::
 
 ## SGB Command $19 — PAL_PRI
 
 If the player overrides the active palette set (a pre-defined or the custom one), it stays in effect until the smiley face is selected again, or the player presses the X button on their SNES controller.
 
-However, if `PAL_PRI` is enabled, then changing the palette set (via any of the above commands except `PAL_TRN`) will switch back to the game's newly-modified palette set, if it wasn't already active.
+However, if `PAL_PRI` is enabled, then changing the palette set (via any `PAL_*` command besides `PAL_TRN`) will switch back to the game's newly-modified palette set, if it wasn't already active.
 
 _Donkey Kong_ (1994) is one known game that appears to use this.
 
-```
- Byte  Content
- 0     Command*8+Length (fixed length=1)
- 1     Palette priority when a palette packet is sent
-         Bit 0 - Priority (0=User, 1=Software)
- 2-F   Not used (zero)
-```
+{{#bits 16 <
+        "" 0:"Header" 1:"Priority"
+}}
+
+The **header** must be $C9.
+
+Bit 0 of the **priority** byte enables (`1`) or disables (`0`) `PAL_PRI`.

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -21,7 +21,7 @@ is set, and (if enabled) a STAT interrupt is requested.
 ## FF41 — STAT: LCD status
 
 {{#bits 8 >
-  "" 6:"LYC int select" 5:"Mode 2 int select" 4:"Mode 1 int select" 3:"Mode 0 int select" 2:"LYC == LY" 1-0:"PPU mode";
+  ""  6:"LYC int select" 5:"Mode 2 int select" 4:"Mode 1 int select" 3:"Mode 0 int select" 2:"LYC == LY" 1-0:"PPU mode";
 }}
 
 - **LYC int select** (*Read/Write*): If set, selects the `LYC` == `LY` condition for [the STAT interrupt](<#INT $48 — STAT interrupt>).

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -20,26 +20,17 @@ is set, and (if enabled) a STAT interrupt is requested.
 
 ## FF41 — STAT: LCD status
 
-```
-Bit 6 - LYC=LY STAT Interrupt source         (1=Enable) (Read/Write)
-Bit 5 - Mode 2 OAM STAT Interrupt source     (1=Enable) (Read/Write)
-Bit 4 - Mode 1 VBlank STAT Interrupt source  (1=Enable) (Read/Write)
-Bit 3 - Mode 0 HBlank STAT Interrupt source  (1=Enable) (Read/Write)
-Bit 2 - LYC=LY Flag                          (0=Different, 1=Equal) (Read Only)
-Bit 1-0 - Mode Flag                          (Mode 0-3, see below) (Read Only)
-          0: HBlank
-          1: VBlank
-          2: Searching OAM
-          3: Transferring Data to LCD Controller
-```
+{{#bits 8 >
+  "" 6:"LYC int select" 5:"Mode 2 int select" 4:"Mode 1 int select" 3:"Mode 0 int select" 2:"LYC == LY" 1-0:"PPU mode";
+}}
 
-The two lower STAT bits show the current [status of the PPU](<#PPU modes>).
-
-Bit 2 is set when [LY](<#FF44 — LY: LCD Y coordinate \[read-only\]>) contains the same value as [LYC](<#FF45 — LYC: LY compare>).
-It is constantly updated.
-
-Bits 3-6 select which sources are used for [the STAT interrupt](<#INT $48 — STAT interrupt>).
-
+- **LYC int select** (*Read/Write*): If set, selects the `LYC` == `LY` condition for [the STAT interrupt](<#INT $48 — STAT interrupt>).
+- **Mode 2 int select** (*Read/Write*): If set, selects the Mode 2 condition for [the STAT interrupt](<#INT $48 — STAT interrupt>).
+- **Mode 1 int select** (*Read/Write*): If set, selects the Mode 1 condition for [the STAT interrupt](<#INT $48 — STAT interrupt>).
+- **Mode 0 int select** (*Read/Write*): If set, selects the Mode 0 condition for [the STAT interrupt](<#INT $48 — STAT interrupt>).
+- **LYC == LY** (*Read-only*): Set when [LY](<#FF44 — LY: LCD Y coordinate \[read-only\]>) contains the same value as [LYC](<#FF45 — LYC: LY compare>); it is constantly updated.
+- **PPU mode** (*Read-only*): Indicates [the PPU's current status](<#PPU modes>).
+  
 ### Spurious STAT interrupts
 
 A hardware quirk in the monochrome Game Boy makes the LCD interrupt

--- a/src/Serial_Data_Transfer_(Link_Cable).md
+++ b/src/Serial_Data_Transfer_(Link_Cable).md
@@ -18,37 +18,39 @@ During a transfer, it has a blend of the outgoing and incoming bytes.
 Each cycle, the leftmost bit is shifted out (and over the wire) and the
 incoming bit is shifted in from the other side:
 
-```
-o7 o6 o5 o4 o3 o2 o1 o0
-o6 o5 o4 o3 o2 o1 o0 i7
-o5 o4 o3 o2 o1 o0 i7 i6
-o4 o3 o2 o1 o0 i7 i6 i5
-o3 o2 o1 o0 i7 i6 i5 i4
-o2 o1 o0 i7 i6 i5 i4 i3
-o1 o0 i7 i6 i5 i4 i3 i2
-o0 i7 i6 i5 i4 i3 i2 i1
-i7 i6 i5 i4 i3 i2 i1 i0
-```
+{{#bits 8 >
+   "Initially" 7:"o.7" 6:"o.6" 5:"o.5" 4:"o.4" 3:"o.3" 2:"o.2" 1:"o.1" 0:"o.0" ;
+   "1 shift"  7:"o.6" 6:"o.5" 5:"o.4" 4:"o.3" 3:"o.2" 2:"o.1" 1:"o.0" 0:"i.7" ;
+   "2 shifts" 7:"o.5" 6:"o.4" 5:"o.3" 4:"o.2" 3:"o.1" 2:"o.0" 1:"i.7" 0:"i.6" ;
+   "3 shifts" 7:"o.4" 6:"o.3" 5:"o.2" 4:"o.1" 3:"o.0" 2:"i.7" 1:"i.6" 0:"i.5" ;
+   "4 shifts" 7:"o.3" 6:"o.2" 5:"o.1" 4:"o.0" 3:"i.7" 2:"i.6" 1:"i.5" 0:"i.4" ;
+   "5 shifts" 7:"o.2" 6:"o.1" 5:"o.0" 4:"i.7" 3:"i.6" 2:"i.5" 1:"i.4" 0:"i.3" ;
+   "6 shifts" 7:"o.1" 6:"o.0" 5:"i.7" 4:"i.6" 3:"i.5" 2:"i.4" 1:"i.3" 0:"i.2" ;
+   "7 shifts" 7:"o.0" 6:"i.7" 5:"i.6" 4:"i.5" 3:"i.4" 2:"i.3" 1:"i.2" 0:"i.1" ;
+   "8 shifts" 7:"i.7" 6:"i.6" 5:"i.5" 4:"i.4" 3:"i.3" 2:"i.2" 1:"i.1" 0:"i.0"
+}}
 
 ## FF02 — SC: Serial transfer control
 
-```
-Bit 7 - Transfer Start Flag (0=No transfer is in progress or requested, 1=Transfer in progress, or requested)
-Bit 1 - Clock Speed (0=Normal, 1=Fast) ** CGB Mode Only **
-Bit 0 - Shift Clock (0=External Clock, 1=Internal Clock)
-```
+{{#bits 8 >
+   "SC" 7:"Transfer enable" 1:"Clock speed" 0:"Clock select"
+}}
+
+- **Transfer enable** (*Read/Write*): If `1`, a transfer is either requested or in progress.
+- **Clock speed** \[*CGB Mode only*\] (*Read/Write*): If set to `1`, the internal clock's speed is doubled.
+- **Clock select** (*Read/Write*): `0` = External clock ("slave"), `1` = Internal clock ("master").
 
 The master Game Boy will load up a data byte in SB and then set
 SC to \$81 (Transfer requested, use internal clock). It will be notified
 that the transfer is complete in two ways: SC's Bit 7 will be cleared
-(that is, SC will be set up \$01), and also the [Serial Interrupt handler](<#INT $58 — Serial interrupt>)
-will be called (that is, the CPU will jump to \$0058).
+(that is, SC will be set up \$01), and also a [Serial interrupt](<#INT $58 — Serial interrupt>)
+will be requested.
 
 The other Game Boy will load up a data byte and can optionally set SC's
 Bit 7 (that is, SC=\$80). Regardless of whether or not it has done this, if
 and when the master wants to conduct a transfer, it will happen
 (pulling whatever happens to be in SB at that time). The externally clocked
-Game Boy will have its [serial interrupt handler](<#INT $58 — Serial interrupt>) called at the end of the
+Game Boy will have a [serial interrupt](<#INT $58 — Serial interrupt>) requested at the end of the
 transfer, and if it bothered to set SC's Bit 7, it will be cleared.
 
 ### Internal Clock
@@ -60,10 +62,10 @@ of the SC register, and on whether the CGB Double Speed Mode is used:
 
 Clock freq | Transfer speed | Conditions
 -----------|----------------|------------
-   8192Hz  |      1KB/s     | Bit 1 cleared, Normal speed
-  16384Hz  |      2KB/s     | Bit 1 cleared, Double-speed Mode
- 262144Hz  |     32KB/s     | Bit 1 set,     Normal speed
- 524288Hz  |     64KB/s     | Bit 1 set,     Double-speed Mode
+   8192 Hz |     1 KB/s     | Bit 1 cleared, Normal speed
+  16384 Hz |     2 KB/s     | Bit 1 cleared, Double-speed Mode
+ 262144 Hz |    32 KB/s     | Bit 1 set,     Normal speed
+ 524288 Hz |    64 KB/s     | Bit 1 set,     Double-speed Mode
 
 ### External Clock
 

--- a/src/Shark_Cheats.md
+++ b/src/Shark_Cheats.md
@@ -25,12 +25,13 @@ Check the [Game Genie manual](http://www.digitpress.com/library/manuals/gameboy/
 
 ## Game Shark (RAM patches)
 
-Game Shark codes consist of eight-digit hex numbers, formatted as
-ABCDEFGH, the meaning of the separate digits is:
+Game Shark codes consist of eight hexadecimal digits, with the following meaning:
 
-` AB    External RAM bank number` \
-` CD    New Data` \
-` GHEF  Memory Address (internal or external RAM, A000-DFFF)`
+{{#bits 8 <
+  "" 0-1:"SRAM bank" 2-3:"New value" 4-7:"Address"
+}}
+
+So, for example, cheat code `010238CD` switches to SRAM bank $01, and writes $02 at address $CD38.
 
 As far as it is understood, patching is implemented by hooking the original
 VBlank interrupt handler, and re-writing RAM values each frame. The

--- a/src/Tile_Data.md
+++ b/src/Tile_Data.md
@@ -70,11 +70,14 @@ mode, controlled by [LCDC bit 4](<#LCDC.4 — BG and Window tile data area>).
 
 Each tile occupies 16 bytes, where each line is represented by 2 bytes:
 
-```
-Byte 0-1  Topmost Line (Top 8 pixels)
-Byte 2-3  Second Line
-etc.
-```
+<table>
+  <thead>
+    <tr><th>Byte</th><th>1<sup>st</sup></th><th>2<sup>nd</sup></th><th>3<sup>rd</sup></th><th>4<sup>th</sup></th><th>...</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Explanation</td><td colspan="2">Topmost line (top 8 pixels)</td><td colspan="2">Second line</td><td>Etc.</td></tr>
+  </tbody>
+</table>
 
 For each line, the first byte specifies the least significant bit of the color
 ID of each pixel, and the second byte specifies the most significant bit. In

--- a/src/Tile_Maps.md
+++ b/src/Tile_Maps.md
@@ -24,7 +24,9 @@ In CGB Mode, an additional map of 32×32 bytes is stored in VRAM Bank 1
 entry in VRAM Bank 0, that is, 1:9800 defines the attributes for the tile at
 0:9800):
 
-{{#bits 8 > "BG attributes" 7:"Priority" 6:"Y flip" 5:"X flip" 3:"Bank" 2-0:"Color palette"}}
+{{#bits 8 > 
+  "BG attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 3:"Bank" 2-0:"Color palette";
+}}
 
 - **Priority**: `0` = No; `1` = Colors 1–3 of the corresponding BG/Window tile are drawn over OBJ, regardless of [OBJ priority](<#Byte 3 — Attributes/Flags>)
 - **Y flip**: `0` = Normal; `1` = Tile is drawn vertically mirrored

--- a/src/Tile_Maps.md
+++ b/src/Tile_Maps.md
@@ -24,18 +24,17 @@ In CGB Mode, an additional map of 32×32 bytes is stored in VRAM Bank 1
 entry in VRAM Bank 0, that is, 1:9800 defines the attributes for the tile at
 0:9800):
 
-```
-Bit 7    BG-to-OAM Priority         (0=Use OAM Priority bit, 1=BG Priority)
-Bit 6    Vertical Flip              (0=Normal, 1=Mirror vertically)
-Bit 5    Horizontal Flip            (0=Normal, 1=Mirror horizontally)
-Bit 4    Not used
-Bit 3    Tile VRAM Bank number      (0=Bank 0, 1=Bank 1)
-Bit 2-0  Background Palette number  (BGP0-7)
-```
+{{#bits 8 > "BG attributes" 7:"Priority" 6:"Y flip" 5:"X flip" 3:"Bank" 2-0:"Color palette"}}
 
-Note that, if the map entry at `0:9800` is tile \$2A, the attribute at
-`1:9800` doesn't define properties for ALL tiles \$2A on-screen, but only
-the one at `0:9800`!
+- **Priority**: `0` = No; `1` = Colors 1–3 of the corresponding BG/Window tile are drawn over OBJ, regardless of [OBJ priority](<#Byte 3 — Attributes/Flags>)
+- **Y flip**: `0` = Normal; `1` = Tile is drawn vertically mirrored
+- **X flip**: `0` = Normal; `1` = Tile is drawn horizontally mirrored
+- **Bank**: `0` = Fetch tile from VRAM bank 0; `1` = Fetch tile from VRAM bank 1
+- **Color palette**: Which of BGP0–7 to use
+
+Bit 4 is ignored by the hardware, but can be written to and read from normally.
+
+Note that, for example, if the byte at `0:9800` is \$2A, the attribute at `1:9800` doesn't define properties for ALL tiles \$2A on-screen, but only the one at `0:9800`!
 
 ### BG-to-OBJ Priority in CGB Mode
 

--- a/src/Timer_and_Divider_Registers.md
+++ b/src/Timer_and_Divider_Registers.md
@@ -41,17 +41,24 @@ due to a timer overflow, the old value is transferred to TIMA.
 
 ## FF07 — TAC: Timer control
 
-```
-Bit  2   - Timer Enable
-Bits 1-0 - Input Clock Select
-           00: CPU Clock / 1024 (DMG, SGB2, CGB Single Speed Mode:   4096 Hz, SGB1:   ~4194 Hz, CGB Double Speed Mode:   8192 Hz)
-           01: CPU Clock / 16   (DMG, SGB2, CGB Single Speed Mode: 262144 Hz, SGB1: ~268400 Hz, CGB Double Speed Mode: 524288 Hz)
-           10: CPU Clock / 64   (DMG, SGB2, CGB Single Speed Mode:  65536 Hz, SGB1:  ~67110 Hz, CGB Double Speed Mode: 131072 Hz)
-           11: CPU Clock / 256  (DMG, SGB2, CGB Single Speed Mode:  16384 Hz, SGB1:  ~16780 Hz, CGB Double Speed Mode:  32768 Hz)
-```
+{{#bits 8 >
+  "TAC" 2:"Enable" 1-0:"Clock select"
+}}
 
-::: tip NOTE
+- **Enable**: Controls whether `TIMA` is incremented.
+  Note that `DIV` is **always** counting, regardless of this bit.
+- **Clock select**: Controls the frequency at which `TIMA` is incremented, as follows:
+  
+  <div class="table-wrapper"><table>
+    <thead>
+      <tr><th rowspan=2>Clock select</th><th rowspan=2>Base clock</th><th colspan=3>Frequency (Hz)</th></tr>
+      <tr><th>DMG, SGB2, CGB in single-speed mode</th><th>SGB1</th><th>CGB in double-speed mode</th></tr>
+    </thead><tbody>
+      <tr><td>00</td><td>CPU Clock / 1024</td><td>  4096</td><td>  ~4194</td><td>  8192</td></tr>
+      <tr><td>01</td><td>CPU Clock / 16  </td><td>262144</td><td>~268400</td><td>524288</td></tr>
+      <tr><td>10</td><td>CPU Clock / 64  </td><td> 65536</td><td> ~67110</td><td>131072</td></tr>
+      <tr><td>11</td><td>CPU Clock / 256 </td><td> 16384</td><td> ~16780</td><td> 32768</td></tr>
+    </tbody>
+  </table></div>
 
-The "Timer Enable" bit only affects the timer (TIMA). The divider (DIV) is **always** counting.
-
-:::
+Note that writing to this register [may increase `TIMA` once](<#Relation between Timer and Divider register>)!


### PR DESCRIPTION
Fixes #318, https://github.com/gbdev/pandocs/issues/293

TODO:
- [ ] Center text in fields, for better readability (e.g. `CGB palette` in the OAM table)