### PR TITLE
Fix image link in MBC5 page

### DIFF
--- a/src/MBC5.md
+++ b/src/MBC5.md
@@ -58,6 +58,6 @@ bit to 1 enables the rumble motor and keeps it enabled until the bit is reset ag
 To control the rumble's intensity, it should be turned on and off repeatedly,
 as seen with these two examples from Pokémon Pinball:
 
-{{#include imgs/MBC5_Rumble_Mild.svg:2:}}
+<img src="imgs/MBC5_Rumble_Mild.svg" width="950px">
 
 <img src="imgs/MBC5_Rumble_Strong.svg" width="950px">


### PR DESCRIPTION
More specifically, the "Mild Rumble" chart near the bottom of the page.