### PR TITLE
Remove useless DB.

### DIFF
--- a/src/OAM_DMA_Transfer.md
+++ b/src/OAM_DMA_Transfer.md
@@ -55,8 +55,6 @@ run_dma_hrampart:
     dec b
     jr nz, .wait
     ret
-
-    db _NARG, WRAM0
 ```
 
 This saves 5 bytes of HRAM, but is slightly slower in most cases due to


### PR DESCRIPTION
Someone in the Discord server was confused by this DB. It doesn't have any purpose within the function, and isn't even valid syntax.