### PR TITLE
Update SGB_Command_Multiplayer.md

### DIFF
--- a/src/SGB_Command_Multiplayer.md
+++ b/src/SGB_Command_Multiplayer.md
@@ -45,4 +45,5 @@ Byte | Player \#
  $xD | 3
  $xC | 4
 
-Next, read joypad state normally. The joypad number count is automatically incremented (or restarted if the last joypad is reached) by P15 going LOW to HIGH, so you can simply repeat reading the joypad state normally until all two (or four) joypads have been read out.
+Next, read joypad state normally.
+The next joypad is automatically selected when P15 goes from LOW (0) to HIGH (1), so you can simply repeat reading the joypad state normally until all two (or four) joypads have been read out.

--- a/src/SGB_Command_Multiplayer.md
+++ b/src/SGB_Command_Multiplayer.md
@@ -46,4 +46,4 @@ Byte | Player \#
  $xC | 4
 
 Next, read joypad state normally.
-The next joypad is automatically selected when P15 goes from LOW (0) to HIGH (1), so you can simply repeat reading the joypad state normally until all two (or four) joypads have been read out.
+The next joypad is automatically selected when P15 goes from LOW (0) to HIGH (1) ([source](https://github.com/CasualPokePlayer/test-roms/blob/sgb-mlt-test/src/intro.asm)), so you can simply repeat reading the joypad state normally until all two (or four) joypads have been read out.

--- a/src/SGB_Command_Multiplayer.md
+++ b/src/SGB_Command_Multiplayer.md
@@ -45,15 +45,4 @@ Byte | Player \#
  $xD | 3
  $xC | 4
 
-Next, read joypad state normally. When completed, set both P14 and P15
-back HIGH, this automatically increments the joypad number (or restarts
-counting once the last joypad is reached). Repeat the procedure until
-you have read out all two (or four) joypads.
-
-If for whatever reason you want to increment the joypad number without
-reading the joypad state you only need to set P15 to LOW before setting
-it back to HIGH. Adjusting P14 does not affect whether or not the joypad
-number will advance, However, if you set P15 to LOW then HIGH then LOW
-again without bringing both P14 and P15 HIGH at any point, it cancels
-the increment until P15 is lowered again. There are games, such as
-Pokémon Yellow, which rely on this cancelling when detecting the SGB.
+Next, read joypad state normally. The joypad number count is automatically incremented (or restarted if the last joypad is reached) by P15 going LOW to HIGH, so you can simply repeat reading the joypad state normally until all two (or four) joypads have been read out.


### PR DESCRIPTION
Testroms indicate that writing $30 to joyp is unneeded for incrementing the joypad count, and the "cancelling" behavior described does not happen in reality (nor does Yellow seem to rely on such behavior). One game (Gamera - Daikaijuu Kuuchuu Kessen) appears to rely on a P15 LOW to HIGH incrementing the joypad number and not the $30 write.

[sgb-mlt-test.zip](https://github.com/mgba-emu/mgba/files/7112150/sgb-mlt-test.zip)
https://github.com/CasualPokePlayer/test-roms/blob/sgb-mlt-test/src/intro.asm

(note, only the top 2 lines have been verified so far, which is enough to confirm this cancelling behavior doesn't really happen (the behavior described is done poorly anyways ("then LOW again... it cancels the increment until P15 is lowered again" you can't lower something already lowered, so what?))