### PR TITLE
Add missing titles to warning boxes

### DIFF
--- a/src/Accessing_VRAM_and_OAM.md
+++ b/src/Accessing_VRAM_and_OAM.md
@@ -1,7 +1,7 @@
 
 # Accessing VRAM and OAM
 
-::: warning
+::: warning Warning
 
 When the PPU is drawing the screen it is directly reading
 from Video Memory (VRAM) and from the Sprite Attribute Table (OAM).

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -88,14 +88,14 @@ to Bit 7 of FF55. In that case reading from FF55 will return how many
 \$10 "blocks" remained (minus 1) in the lower 7 bits, but Bit 7 will
 be read as "1". Stopping the transfer doesn't set HDMA1-4 to \$FF.
 
-::: warning
+::: warning WARNING
 
 HBlank DMA should not be started (write to FF55) during a HBlank
 period (STAT mode 0).
 
 If the transfer's destination address overflows, the transfer stops
-prematurely. \[Note: what's the state of the registers if this happens
-?\]
+prematurely.
+The status of the registers if this happens still needs to be [investigated](https://github.com/gbdev/pandocs/issues/364).
 
 :::
 

--- a/src/Interrupt_Sources.md
+++ b/src/Interrupt_Sources.md
@@ -23,7 +23,7 @@ state (inactive=low and active=high) logically ORed into a shared
 A STAT interrupt will be triggered by a rising edge (transition from 
 low to high) on the STAT interrupt line.
 
-::: warning
+::: warning STAT blocking
 
 If a STAT interrupt source logically ORs the interrupt line high while 
 (or immediately after) it's already set high by another source, then 

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -132,7 +132,7 @@ The boot ROM picks a compatibility palette using an ID computed using the follow
 The resulting palettes ID is used to pick 3 palettes out of a table via a fairly complex mechanism.
 The user can override this choice using certain button combinations during the logo animation; some of these manual choices are identical to auto-colorizations, [but others are unique](https://tcrf.net/Notes:Game_Boy_Color_Bootstrap_ROM#Manual_Select_Palette_Configurations).
 
-::: tip
+::: tip Available palettes
 
 A table of checksums (and tie-breaker fourth letters when applicable) and the corresponding palettes can be found [on TCRF](https://tcrf.net/Notes:Game_Boy_Color_Bootstrap_ROM#Assigned_Palette_Configurations).
 
@@ -196,7 +196,7 @@ Strangely, despite correcting the TOCTTOU vulnerability, the CGB-AGB boot ROM do
 Regardless of the console you intend for your game to run on, it is prudent to rely on as little of the following as possible, barring what is mentioned elsewhere in this documentation to detect which system you are running on.
 This ensures maximum compatibility, both across consoles and cartridges (especially flashcarts, which typically run their own menu code before your game), increases reliability, and is generally considered good practice.
 
-::: warning
+::: warning Use it at your own risk
 
 Some of the information below is highly volatile, due to the complexity of some of the boot ROM behaviors; thus, some of it may contain errors.
 Rely on it at your own risk.

--- a/src/Rendering.md
+++ b/src/Rendering.md
@@ -4,7 +4,7 @@
 The Game Boy outputs graphics to a 160x144 pixel LCD, using a quite complex
 mechanism to facilitate rendering.
 
-::: warning
+::: warning Terminology
 
 Sprites/graphics terminology can vary a lot among different platforms, consoles, 
 users and communities. You may be familiar with slightly different definitions.

--- a/src/Scrolling.md
+++ b/src/Scrolling.md
@@ -32,7 +32,7 @@ The Window is visible (if enabled) when both coordinates are in the ranges
 WX=0..166, WY=0..143 respectively. Values WX=7, WY=0 place the Window at the
 top left of the screen, completely covering the background.
 
-::: warning
+::: warning Warning
 
 WX values 0 and 166 are unreliable due to hardware bugs.
 

--- a/src/pixel_fifo.md
+++ b/src/pixel_fifo.md
@@ -252,7 +252,7 @@ restored and pixels are pushed to the LCD normally when rendering pixels:
 - At the end of mode 2 (oam search)
 - For only 2 cycles when entering HBlank (mode 0) and in double speed mode
 
-::: warning Note
+::: tip Note
 
 These conditions are checked only when entering STOP mode and the
 PPU's access to CGB palettes is always restored upon leaving STOP mode.


### PR DESCRIPTION
Misc improvements to the warning boxes. I added titles where they were missing (sometimes using "warning" sometimes using a more meaningful one) and then reworded a [Note: x need to be investigate] to link to the actual issue discussing the behaviour.