### PR TITLE
Add danger box and switch to it where necessary

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,7 +81,7 @@ Those mimick Vuepress' [custom containers](https://vuepress.vuejs.org/guide/mark
 
 These are rendered as "info boxes".
 
-- `type` must be `tip`, or `warning`.
+- `type` must be `tip`, `warning`, or `danger`.
 - `HEADING` can contain spaces and will be the title of the box. It should be `Warning`, `Tip`, or something illustrative of what the box contains.
 - Both `:::` lines **must** be surrounded by empty lines, otherwise they won't be processed.
 

--- a/custom/style.css
+++ b/custom/style.css
@@ -93,6 +93,16 @@ code {
     color: var(--c-warning-title);
 }
 
+.box.danger {
+    border-left-color: var(--c-danger);
+    background-color: rgba(255, 0, 0, .15);
+    color: var(--c-danger-text);
+}
+
+.box.danger > .box-title {
+    color: var(--c-danger-title);
+}
+
 .spacer {
     width: 100%;
     height: 3px;
@@ -109,6 +119,10 @@ code {
     --c-warning: #e7c000;
     --c-warning-bg: #fffae3;
     --c-warning-title: #ad9000;
+    /* Danger boxes base styling */
+    --c-danger: #cc0000;
+    --c-danger-text: #660000;
+    --c-danger-title: #990000;
 }
 
 /* Theme-wide CSS variables */

--- a/custom/style.css
+++ b/custom/style.css
@@ -129,10 +129,14 @@ code {
 
 .ayu {
     --c-warning-text: #eac100;
+    --c-danger-text: #ff2929;
+    --c-danger-title: #dc0000;
 }
 
 .coal {
     --c-warning-text: #eac100;
+    --c-danger-text: #ff2929;
+    --c-danger-title: #dc0000;
 }
 
 .light {
@@ -141,6 +145,8 @@ code {
 
 .navy {
     --c-warning-text: #eac100;
+    --c-danger-text: #ff2929;
+    --c-danger-title: #dc0000;
 }
 
 .rust {

--- a/renderer/src/main.rs
+++ b/renderer/src/main.rs
@@ -180,7 +180,7 @@ fn render(path: &mut PathBuf, name: &str, index: usize) -> Result<()> {
                     }
                     in_box = true;
 
-                    let box_type = if ["tip", "warning"].contains(&box_type) {
+                    let box_type = if ["tip", "warning", "danger"].contains(&box_type) {
                         box_type
                     } else {
                         let mut stderr = StandardStream::stderr(ColorChoice::Auto);

--- a/src/LCDC.md
+++ b/src/LCDC.md
@@ -22,7 +22,7 @@ This bit controls whether the LCD is on and the PPU is active. Setting
 it to 0 turns both off, which grants immediate and full access to VRAM,
 OAM, etc.
 
-::: warning
+::: danger
 
 Stopping LCD operation (Bit 7 from 1 to 0) may be performed
 during VBlank ONLY, disabling the display outside

--- a/src/LCDC.md
+++ b/src/LCDC.md
@@ -22,7 +22,7 @@ This bit controls whether the LCD is on and the PPU is active. Setting
 it to 0 turns both off, which grants immediate and full access to VRAM,
 OAM, etc.
 
-::: danger
+::: danger CAUTION
 
 Stopping LCD operation (Bit 7 from 1 to 0) may be performed
 during VBlank ONLY, disabling the display outside

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -160,7 +160,7 @@ While it may make sense for the boot ROM to at least partially verify the ROM's 
 
 ### Legal implications
 
-::: warning Caution
+::: danger Caution
 
 The following is advisory, but **is not legal advice**.
 If necessary (e.g. commercial releases with logos on the boxes), consult a lawyer.


### PR DESCRIPTION
We are still missing a "danger" box as possible custom container. Even if I see the necessity to use it just of couple of times in the entire document (when it's possible to damage the Game Boy, when we are telling to ask a lawyer) it's still a nice to have.

The styling actually plays well only with the light themes, values must be moved to variables (blocked by #363, once that is merged here we should move variables from style.css to variables.css).


Example:
![image](https://user-images.githubusercontent.com/14352721/135694191-55bc8975-fe2c-4bd9-9d04-798167782044.png)
