### PR TITLE
Add a page on the M161 mapper

### DIFF
--- a/src/M161.md
+++ b/src/M161.md
@@ -2,36 +2,41 @@
 
 The M161 is a simple multi-cart mapper by Mani (Nintendo's official Chinese distributor). 
 This mapper only allows for 8 separate 32 KiB banks, with a limit of 1 bankswitch, preventing any bankswitches afterward.
-This gives 1 bank for the main menu, and a maximum of 7 different 32 KiB games. No SRAM can be applied to this mapper, so only purely MBC-less titles can be used.
+This gives 1 bank for the main menu, and a maximum of 7 different 32 KiB games.
+No SRAM can be applied to this mapper, so only purely MBC-less titles can be used.
 
-This mapper is only known to be used in a single cartridge: Mani's 4 in 1 cartridge with Tetris, Tennis, Alleyway, and Yakuman.
-All later Mani 4 in 1 cartridges use the MMM01 mapper, so the M161 mapper could be considered the predecessor to the MMM01.
+This mapper is only known to be used in a single cartridge: Mani's 4 in 1 cartridge, which contains Tetris, Tennis, Alleyway, and Yakuman.
+All later Mani 4 in 1 cartridges use [the MMM01 mapper](MMM01), so the M161 mapper could be considered the predecessor to the MMM01.
 
-The mapper is really just a simple off-the-shelf 74HC161A used a flip-flop. The 74HC161A contains 4 input pins and 4 output pins, and another pin for latching the input pins to the output pins.
-The first 3 of the input pins are connected to the lower 3-bits of incoming write data, with the 4th pin kept high. The first 3 of the output pins are connected to the ROM addressing pins.
-The 4th output pin (which corresponds to the always high input pin) is connected to the latching pin. Bit-15 of the write address is also connected (OR'd) with the latching pin.
-The latching pin latches the input pins to the output pins on a high to low, so when a ROM write comes through (bit-15 = 0), the input pins will be latched to the output pins.
-Since 4th output pin will be high, this will render it no longer possible for a high to low latch signal to occur, thus preventing further bankswitches.
-
+The mapper is really just a simple off-the-shelf 74HC161A used a flip-flop.
+The 74HC161A contains 4 input pins and 4 output pins, and another pin for latching the input pins to the output pins.
+The first 3 of the input pins are connected to the lower 3 bits of incoming write data, with the 4th pin kept high.
+The first 3 of the output pins are connected to the ROM addressing pins.
+The 4th output pin (which corresponds to the always high input pin) is connected to the latching pin.
+Bit 15 of the write address is also connected to (OR'd with) the latching pin.
+The latching pin latches the input pins to the output pins on a transition from high to low, so when a ROM write comes through (bit 15 = 0), the input pins will be latched to the output pins.
+Since 4th output pin will be high, the signal cannot become low anymore, thus preventing further bankswitches.
 
 ## Memory
 
 ### 0000-7FFF - ROM Bank $00-$07 (Read Only)
 
-This area contains a 32 KiB bank of ROM. On startup, this will contain the first 32 KiB of ROM (bank 0).
+This area contains a 32 KiB bank of ROM.
+On startup, this will contain the first 32 KiB of ROM (bank 0).
 
 ## Registers
 
 ### 0000-7FFF - ROM Bank Number (Write Only)
 
-This 3-bit register (range $00-$07) selects the ROM bank number for the $0000-$7FFF region. Like other mappers, the high bits are discarded.
+This 3-bit register (range $00-$07) selects the ROM bank number for the $0000-$7FFF region.
+Like other mappers, the high bits are discarded.
 
-Only 1 bankswitch is allowed per session, once any write to this register occurs (even to bank 0), all future writes will do nothing until a hard reset.
+Only 1 bankswitch is allowed per session, once any write to this register occurs (even if set to 0), all future writes will be ignored until the mapper is powered down.
 
 ## Operation Notes
 
 Because the full 32 KiB range is switched over, caution should be taken, as the entire ROM range will change.
-It may be best to have the bankswitch code placed right before $0100, as to slide down to a game's init sequence.
+It may be best to have the bankswitch code placed right before $0100, so as to fall through to [the game's init sequence](https://gbdev.io/pandocs/The_Cartridge_Header.html#0100-0103---entry-point).
 
 ### References
 

--- a/src/M161.md
+++ b/src/M161.md
@@ -6,7 +6,7 @@ This gives 1 bank for the main menu, and a maximum of 7 different 32 KiB games.
 This mapper does not support SRAM, so only purely MBC-less titles can be used.
 
 This mapper is only known to be used in a single cartridge: Mani's 4 in 1 cartridge, which contains Tetris, Tennis, Alleyway, and Yakuman.
-All later Mani 4 in 1 cartridges use [the MMM01 mapper](MMM01), so the M161 mapper could be considered the predecessor to the MMM01.
+All later Mani 4 in 1 cartridges use [the MMM01 mapper](<#MMM01>), so the M161 mapper could be considered the predecessor to the MMM01.
 
 The mapper is really just a simple off-the-shelf 74HC161A used a flip-flop.
 The 74HC161A contains 4 input pins and 4 output pins, and another pin for latching the input pins to the output pins.
@@ -36,7 +36,7 @@ Only 1 bankswitch is allowed per session, once any write to this register occurs
 ## Operation Notes
 
 Because the full 32 KiB range is switched over, caution should be taken, as the entire ROM range will change.
-It may be best to have the bankswitch code placed right before $0100, so as to fall through to [the game's init sequence](https://gbdev.io/pandocs/The_Cartridge_Header.html#0100-0103---entry-point).
+It may be best to have the bankswitch code placed right before $0100, so as to fall through to [the game's init sequence](<#0100-0103 - Entry Point>).
 
 ### References
 

--- a/src/M161.md
+++ b/src/M161.md
@@ -1,0 +1,38 @@
+# M161
+
+The M161 is a simple multi-cart mapper by Mani (Nintendo's official Chinese distributor). 
+This mapper only allows for 8 separate 32 KiB banks, with a limit of 1 bankswitch, preventing any bankswitches afterward.
+This gives 1 bank for the main menu, and a maximum of 7 different 32 KiB games. No SRAM can be applied to this mapper, so only purely MBC-less titles can be used.
+
+This mapper is only known to be used in a single cartridge: Mani's 4 in 1 cartridge with Tetris, Tennis, Alleyway, and Yakuman.
+All later Mani 4 in 1 cartridges use the MMM01 mapper, so the M161 mapper could be considered the predecessor to the MMM01.
+
+The mapper is really just a simple off-the-shelf 74HC161A used a flip-flop. The 74HC161A contains 4 input pins and 4 output pins, and another pin for latching the input pins to the output pins.
+The first 3 of the input pins are connected to the lower 3-bits of incoming write data, with the 4th pin kept high. The first 3 of the output pins are connected to the ROM addressing pins.
+The 4th output pin (which corresponds to the always high input pin) is connected to the latching pin. Bit-15 of the write address is also connected (OR'd) with the latching pin.
+The latching pin latches the input pins to the output pins on a high to low, so when a ROM write comes through (bit-15 = 0), the input pins will be latched to the output pins.
+Since 4th output pin will be high, this will render it no longer possible for a high to low latch signal to occur, thus preventing further bankswitches.
+
+
+## Memory
+
+### 0000-7FFF - ROM Bank $00-$07 (Read Only)
+
+This area contains a 32 KiB bank of ROM. On startup, this will contain the first 32 KiB of ROM (bank 0).
+
+## Registers
+
+### 0000-7FFF - ROM Bank Number (Write Only)
+
+This 3-bit register (range $00-$07) selects the ROM bank number for the $0000-$7FFF region. Like other mappers, the high bits are discarded.
+
+Only 1 bankswitch is allowed per session, once any write to this register occurs (even to bank 0), all future writes will do nothing until a hard reset.
+
+## Operation Notes
+
+Because the full 32 KiB range is switched over, caution should be taken, as the entire ROM range will change.
+It may be best to have the bankswitch code placed right before $0100, as to slide down to a game's init sequence.
+
+### References
+
+- Source: [M161 Schematic](https://pics.tauwasser.eu/image/schematic-dmg-m161-m01-v10.pdDz) on tauwasser pics

--- a/src/M161.md
+++ b/src/M161.md
@@ -3,7 +3,7 @@
 The M161 is a simple multi-cart mapper by Mani (Nintendo's official Chinese distributor). 
 This mapper only allows for 8 separate 32 KiB banks, with a limit of 1 bankswitch, preventing any bankswitches afterward.
 This gives 1 bank for the main menu, and a maximum of 7 different 32 KiB games.
-No SRAM can be applied to this mapper, so only purely MBC-less titles can be used.
+This mapper does not support SRAM, so only purely MBC-less titles can be used.
 
 This mapper is only known to be used in a single cartridge: Mani's 4 in 1 cartridge, which contains Tetris, Tennis, Alleyway, and Yakuman.
 All later Mani 4 in 1 cartridges use [the MMM01 mapper](MMM01), so the M161 mapper could be considered the predecessor to the MMM01.
@@ -11,7 +11,7 @@ All later Mani 4 in 1 cartridges use [the MMM01 mapper](MMM01), so the M161 mapp
 The mapper is really just a simple off-the-shelf 74HC161A used a flip-flop.
 The 74HC161A contains 4 input pins and 4 output pins, and another pin for latching the input pins to the output pins.
 The first 3 of the input pins are connected to the lower 3 bits of incoming write data, with the 4th pin kept high.
-The first 3 of the output pins are connected to the ROM addressing pins.
+The first 3 of the output pins are connected to the ROM addressing pins (RA15-RA17).
 The 4th output pin (which corresponds to the always high input pin) is connected to the latching pin.
 Bit 15 of the write address is also connected to (OR'd with) the latching pin.
 The latching pin latches the input pins to the output pins on a transition from high to low, so when a ROM write comes through (bit 15 = 0), the input pins will be latched to the output pins.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -66,6 +66,7 @@
   - [MBC6](./MBC6.md)
   - [MBC7](./MBC7.md)
   - [MMM01](./MMM01.md)
+  - [M161](./M161.md)
   - [HuC1](./HuC1.md)
   - [Other MBCs](./othermbc.md)
 


### PR DESCRIPTION
The wording here could be improved probably, not sure if I did all the formatting right. Also not sure if I should go link to some random site for a 74HC161A datasheet here (numerous sites have them, not sure of any "proper" site to cite here).