### PR TITLE
Improve readability of slow external clock

### DIFF
--- a/src/Serial_Data_Transfer_(Link_Cable).md
+++ b/src/Serial_Data_Transfer_(Link_Cable).md
@@ -71,11 +71,10 @@ The external clock is typically supplied by another Game Boy, but might
 be supplied by another computer (for example if connected to a PC's
 parallel port), in that case the external clock may have any speed. Even
 the old/monochrome Game Boy is reported to recognize external clocks of
-up to 500 kHz. And there is no limitation into the other direction - even
-when suppling an external clock speed of "1 bit per month", then the
-Game Boy will still eagerly wait for the next bit(s) to be transferred.
-It isn't required that the clock pulses are sent at an regular interval
-either.
+up to 500 kHz. And there is no limitation in the other direction, even
+when suppling an external clock speed of "1 bit per month," the Game Boy
+will eagerly wait for the next bit to be transferred. It isn't required
+that the clock pulses are sent at an regular interval either.
 
 ## Timeouts
 


### PR DESCRIPTION
- Fixes "into" -> "in" the other direction
- Uses paired commas instead of unpaired hyphen
- Fixes commas placement after quote