### PR TITLE
Added preliminary HuC-3 documentation.

### DIFF
--- a/src/HuC1.md
+++ b/src/HuC1.md
@@ -1,10 +1,9 @@
 # HuC1
 
-HuC1 is an MBC used by some Game Boy games which, besides doing the
-usual MBC stuff, also provides infrared communication. A lot of sources
-on the internet said that HuC1 was “similar to MBC1”, but they didn’t
-provide any detail. I took a look, and it turns out that HuC1 differs
-from MBC1 quite a lot.
+HuC1 is an MBC developed by Hudson Soft. It implements ROM and RAM
+banking, and also provides infrared communication. Many sources on the
+internet said that HuC1 was “similar to MBC1”, without providing any
+detail. However, the HuC1 differs from MBC1 significantly.
 
 ## Memory Map
 
@@ -18,12 +17,13 @@ Address range | Feature
 
 ### 0000–1FFF — IR Select [write-only]
 
-Most MBCs let you disable the cartridge RAM to prevent accidental
-writes. HuC1 doesn’t do this, instead you use this register to switch
-the A000–BFFF region between “RAM mode” and “IR mode” (described
-below). Write $0E to switch to IR mode, and anything else to switch to
-RAM mode. Nevertheless some HuC1 games attempt to write $0A and $00 to
-this region as if it would enable/disable cart RAM.
+Most MBCs can disable the cartridge RAM to prevent accidental writes.
+HuC1 doesn’t do this. Instead, this register swtiches the $A000–BFFF
+region between “RAM mode” and “IR mode” (described below). Write $0E to
+switch to IR mode, or anything else to switch to RAM mode.
+
+Some HuC1 games still write $0A and $00 to this region as if it would
+enable/disable cart RAM.
 
 ### 2000–3FFF — ROM Bank Number [write-only]
 
@@ -44,9 +44,10 @@ safely ignore these writes.
 When in “IR mode” (wrote $0E to $0000), the IR register is visible
 here. Write to this region to control the IR transmitter. $01 turns it
 on, $00 turns it off. Read from this region to see either $C1 (saw
-light) or $C0 (did not see light). When in “RAM mode” (wrote
-something other than $0E to $0000) this region behaves like normal cart
-RAM.
+light) or $C0 (did not see light).
+
+When in “RAM mode” (wrote something other than $0E to $0000) this region
+behaves like normal cart RAM.
 
 ## External links
 

--- a/src/HuC1.md
+++ b/src/HuC1.md
@@ -1,50 +1,51 @@
 # HuC1
 
-HuC1 is an MBC used by some Game Boy games which besides doing the usual
-MBC stuff, also provides IR comms. A lot of sources on the internet said
-that HuC1 was \"similar to MBC1\", but they didn\'t provide any detail.
-I took a look, and it turns out that HuC1 differs from MBC1 quite a lot.
+HuC1 is an MBC used by some Game Boy games which, besides doing the
+usual MBC stuff, also provides infrared communication. A lot of sources
+on the internet said that HuC1 was \"similar to MBC1\", but they didn\'t
+provide any detail. I took a look, and it turns out that HuC1 differs
+from MBC1 quite a lot.
 
 ## Memory Map
 
 Address range | Feature
 --------------|------------------------------------
-  $0000-1FFF  | RAM/IR select (when writing only)
-  $2000-3FFF  | ROM bank select (when writing only)
-  $4000-5FFF  | RAM bank select (when writing only)
-  $6000-7FFF  | Nothing?
-  $A000-BFFF  | Cart RAM or IR register
+  $0000–1FFF  | RAM/IR select (when writing only)
+  $2000–3FFF  | ROM bank select (when writing only)
+  $4000–5FFF  | RAM bank select (when writing only)
+  $6000–7FFF  | Nothing?
+  $A000–BFFF  | Cart RAM or IR register
 
-### 0000-1FFF IR Select (Write Only)
+### 0000–1FFF IR Select (Write-Only)
 
 Most MBCs let you disable the cartridge RAM to prevent accidental
 writes. HuC1 doesn\'t do this, instead you use this register to switch
-the A000-BFFF region between \"RAM mode\" and \"IR mode\" (described
-below). Write 0x0E to switch to IR mode, and anything else to switch to
-RAM mode. Nevertheless some HuC1 games attempt to write 0x0A and 0x00 to
+the A000–BFFF region between \"RAM mode\" and \"IR mode\" (described
+below). Write $0E to switch to IR mode, and anything else to switch to
+RAM mode. Nevertheless some HuC1 games attempt to write $0A and $00 to
 this region as if it would enable/disable cart RAM.
 
-### 2000-3FFF ROM Bank Number (Write Only)
+### 2000–3FFF ROM Bank Number (Write-Only)
 
 HuC1 can accept a bank number of at least 6 bits here.
 
-### 4000-5FFF RAM Bank Select (Write Only)
+### 4000–5FFF RAM Bank Select (Write-Only)
 
 HuC1 can accept a bank number of at least 2 bits here.
 
-### 6000-7FFF Nothing? (Write Only)
+### 6000–7FFF Nothing? (Write-Only)
 
 Writes to this region seem to have no effect. Even so, some games do
 write to this region, as if it had the same effect as on MBC1. You may
 safely ignore these writes.
 
-### A000-BFFF Cart RAM or IR register (Read/Write)
+### A000–BFFF Cart RAM or IR register (Read/Write)
 
-When in \"IR mode\" (wrote 0x0E to 0x0000), the IR register is visible
-here. Write to this region to control the IR transmitter. 0x01 turns it
-on, 0x00 turns it off. Read from this region to see either 0xC1 (saw
-light) or 0xC0 (did not see light). When in \"RAM mode\" (wrote
-something other than 0x0E to 0x000) this region behaves like normal cart
+When in \"IR mode\" (wrote $0E to 0000), the IR register is visible
+here. Write to this region to control the IR transmitter. $01 turns it
+on, $00 turns it off. Read from this region to see either $C1 (saw
+light) or $C0 (did not see light). When in \"RAM mode\" (wrote
+something other than $0E to 0000) this region behaves like normal cart
 RAM.
 
 ## External links

--- a/src/HuC1.md
+++ b/src/HuC1.md
@@ -1,9 +1,8 @@
 # HuC1
 
 HuC1 is an MBC developed by Hudson Soft. It implements ROM and RAM
-banking, and also provides infrared communication. Many sources on the
-internet said that HuC1 was “similar to MBC1”, without providing any
-detail. However, the HuC1 differs from MBC1 significantly.
+banking, and also provides infrared communication.
+Despite many sources on the internet claiming that HuC1 is “similar to MBC1”, it actually differs from MBC1 significantly.
 
 ## Memory Map
 

--- a/src/HuC1.md
+++ b/src/HuC1.md
@@ -2,7 +2,7 @@
 
 HuC1 is an MBC used by some Game Boy games which, besides doing the
 usual MBC stuff, also provides infrared communication. A lot of sources
-on the internet said that HuC1 was \"similar to MBC1\", but they didn\'t
+on the internet said that HuC1 was “similar to MBC1”, but they didn’t
 provide any detail. I took a look, and it turns out that HuC1 differs
 from MBC1 quite a lot.
 
@@ -16,36 +16,36 @@ Address range | Feature
   $6000–7FFF  | Nothing?
   $A000–BFFF  | Cart RAM or IR register
 
-### 0000–1FFF IR Select (Write-Only)
+### 0000–1FFF — IR Select [write-only]
 
 Most MBCs let you disable the cartridge RAM to prevent accidental
-writes. HuC1 doesn\'t do this, instead you use this register to switch
-the A000–BFFF region between \"RAM mode\" and \"IR mode\" (described
+writes. HuC1 doesn’t do this, instead you use this register to switch
+the A000–BFFF region between “RAM mode” and “IR mode” (described
 below). Write $0E to switch to IR mode, and anything else to switch to
 RAM mode. Nevertheless some HuC1 games attempt to write $0A and $00 to
 this region as if it would enable/disable cart RAM.
 
-### 2000–3FFF ROM Bank Number (Write-Only)
+### 2000–3FFF — ROM Bank Number [write-only]
 
 HuC1 can accept a bank number of at least 6 bits here.
 
-### 4000–5FFF RAM Bank Select (Write-Only)
+### 4000–5FFF — RAM Bank Select [write-only]
 
 HuC1 can accept a bank number of at least 2 bits here.
 
-### 6000–7FFF Nothing? (Write-Only)
+### 6000–7FFF — Nothing? [write-only]
 
 Writes to this region seem to have no effect. Even so, some games do
 write to this region, as if it had the same effect as on MBC1. You may
 safely ignore these writes.
 
-### A000–BFFF Cart RAM or IR register (Read/Write)
+### A000–BFFF — Cart RAM or IR register [read/write]
 
-When in \"IR mode\" (wrote $0E to 0000), the IR register is visible
+When in “IR mode” (wrote $0E to $0000), the IR register is visible
 here. Write to this region to control the IR transmitter. $01 turns it
 on, $00 turns it off. Read from this region to see either $C1 (saw
-light) or $C0 (did not see light). When in \"RAM mode\" (wrote
-something other than $0E to 0000) this region behaves like normal cart
+light) or $C0 (did not see light). When in “RAM mode” (wrote
+something other than $0E to $0000) this region behaves like normal cart
 RAM.
 
 ## External links

--- a/src/HuC3.md
+++ b/src/HuC3.md
@@ -1,0 +1,171 @@
+# HuC-3
+
+HuC-3 is an MBC used by some Game Boy games which, besides doing the
+usual MBC stuff, also provides a real-time clock, speaker, and infrared
+communication. The CR2025 coin cell is user-replaceable. It is a
+successor to the [HuC1](./HuC1.md).
+
+The HuC-3 is poorly understood. Observed behavior suggests the
+real-time clock and tone generator are implemented using a 4-bit
+microcontroller core with internal program ROM.
+
+
+## Memory
+
+### 0000–3FFF – ROM Bank 00 (Read-Only)
+
+Contains the first 16 KiB of the ROM.
+
+### 4000–7FFF – ROM Bank 00–7F (Read-Only)
+
+This area may contain any of the further 16 KiB banks of the ROM. It is
+unknown whether bank $00 can be selected here.
+
+### A000–BFFF – RAM Bank 00–03, or RTC/IR register (Read/Write)
+
+Depending on the current register selection and RAM Bank Number (see
+below), this memory space is used to access an 8 KiB external RAM Bank,
+or a single I/O Register.
+
+
+## Memory Control Registers
+
+### 0000–1FFF – RAM/RTC/IR Select (Write-Only)
+
+Writing to this register maps cart RAM, RTC registers or IR registers
+into memory at A000–BFFF. Only the lower 4 bits are significant.
+
+Value | Feature
+------|-----------------------------
+  $0  | Cart RAM (read-only)
+  $A  | Cart RAM (read/write)
+  $B  | RTC command/argument (write)
+  $C  | RTC command/response (read)
+  $D  | RTC semaphore (read/write)
+  $E  | IR (read/write)
+
+If any other value is written, reads from A000–BFFF return open bus
+values (often $FF, but not guaranteed), and writes are ignored.
+
+### 2000–3FFF – ROM Bank Number (Write-Only)
+
+HuC-3 can accept a 7-bit bank number here.
+
+### 4000–5FFF – RAM Bank Select (Write-Only)
+
+HuC-3 can accept a bank number of at least 2 bits here.
+
+### 6000–7FFF – Nothing? (Write-Only)
+
+Games write $01 here on startup, but it doesn\'t seem to have any
+observable effect.
+
+
+## I/O Registers
+
+These registers are accessed by reading or writing int the A000–BFFF
+range after setting the RAM/RTC/IR Select register. Address lines
+A12–A0 are not connected to the HuC-3 chip, so the offset within the
+range is ignored. Data line D7 is not connected to the HuC-3 chip, so
+the most significant bit of reads always returns an open bus value
+(usually high), and the most significant bit of writes is always
+ignored.
+
+The RTC MCU communication protocol is described below.
+
+### B – RTC Command/Argument (Write)
+
+The value written consists of a command in bits 6-4, and an argument
+value in bits 4–0. For example the value $62 is command $6 with argument
+value $2. Writing to this register just sets the values in the mailbox
+registers – it does not cause the command to be executed.
+
+### C – RTC Command/Response (Read)
+
+When read, bits 6–4 return the last command written to register $B, and
+bits 3–0 contain the result from the last command executed.
+
+### D – RTC Semaphore (Read/Write)
+
+When reading, the least significant bit is high when the RTC MCU is
+ready to receive a command, or low when the RTC MCU is busy.
+
+Writing with the least significant bit clear requests that the RTC MCU
+execute the last command written to register $B.
+
+### E – IR (Read/Write)
+
+Similar to the equivalent register of the HuC-1. The least significant
+bit is used for infrared communication.
+
+
+## RTC Communication Protocol
+
+The HuC-3 chip provides read and write access to a 256-nybble window
+into the RTC MCU\'s internal memory. Multi-nybble values are stored
+with the least significant nybble at the lowest address (little Endian).
+There are commands for setting the access address, reading and writing
+values, and a few higher-level operations.
+
+Games use the following sequence to execute a command:
+
+* Write $0D to 0000 (select RTC Semaphore register)
+* Poll A000 until least significant bit is set (wait until ready)
+* Write $0B to 0000 (select RTC Command/Argument register)
+* Write command and argument to A000
+* Write $0D to 0000 (select RTC semaphore register)
+* Write $FE to A000 (clear semaphore, requesting MCU execute command)
+* Poll A000 until least significant bit is set (wait for completion)
+* Write $0C to 0000 (select RTC Command/Response register)
+* Read A000 and use value from 4 least significant bits
+
+(The last two steps are not applicable for commands that don\'t produce
+a response.)
+
+Known commands:
+
+Command | Description
+--------|-----------------------------------------------
+  $1    | Read value and increment access address
+  $3    | Write value and increment access address
+  $4    | Set access address least significant nybble
+  $5    | Set access address most significant nybble
+  $6    | Execute extended command specified by argument
+
+Pocket Family GB2 uses command $2 with argument $0, its purpose is
+unknown. Commands $0 and $7 have not been observed.
+
+The following extended commands have been observed:
+
+Command | Description
+--------|------------------------------------------------------------
+  $0    | Copy current time to locations 00–06
+  $1    | Copy locations 00–06 to current time, and update event time
+  $2    | Seems to be some kind of status request
+  $E    | Executing twice triggers tone generator
+
+Commands $0 and $1 are used to read and write the current time
+atomically. Writing the current time in this way also updates the event
+time to maintain the remaining duration until the event occurs.
+
+Command $2 is used on start and seems to be some kind of status
+request. The games will not start if the result is not $1.
+
+### RTC Location Map
+
+The purpose of some locations has been inferred by observing behavior:
+
+Location | Purpose
+---------|------------------------------------------------------------
+  00–06  | Output or input space for reading or writing current time
+  10–12  | Minute of day counter (rolls over at 1440)
+  13–15  | Day counter
+  26     | Tone selection in two least significant bits
+  27     | Tone generator enabled if value is 1 (all bits checked)
+  58–5A  | Event time minutes
+  5B–5D  | Event time days
+
+
+## External links
+
+- Source: [GBDev Forums thread](https://gbdev.gg8.se/forums/viewtopic.php?id=744)

--- a/src/HuC3.md
+++ b/src/HuC3.md
@@ -12,16 +12,16 @@ microcontroller core with internal program ROM.
 
 ## Memory
 
-### 0000–3FFF – ROM Bank 00 (Read-Only)
+### 0000–3FFF — ROM Bank 00 [read-only]
 
 Contains the first 16 KiB of the ROM.
 
-### 4000–7FFF – ROM Bank 00–7F (Read-Only)
+### 4000–7FFF — ROM Bank 00–7F [read-only]
 
 This area may contain any of the further 16 KiB banks of the ROM. It is
 unknown whether bank $00 can be selected here.
 
-### A000–BFFF – RAM Bank 00–03, or RTC/IR register (Read/Write)
+### A000–BFFF — RAM Bank 00–03, or RTC/IR register [read/write]
 
 Depending on the current register selection and RAM Bank Number (see
 below), this memory space is used to access an 8 KiB external RAM Bank,
@@ -30,10 +30,10 @@ or a single I/O Register.
 
 ## Memory Control Registers
 
-### 0000–1FFF – RAM/RTC/IR Select (Write-Only)
+### 0000–1FFF — RAM/RTC/IR Select [read/write]
 
 Writing to this register maps cart RAM, RTC registers or IR registers
-into memory at A000–BFFF. Only the lower 4 bits are significant.
+into memory at $A000–BFFF. Only the lower 4 bits are significant.
 
 Value | Feature
 ------|-----------------------------
@@ -44,26 +44,26 @@ Value | Feature
   $D  | RTC semaphore (read/write)
   $E  | IR (read/write)
 
-If any other value is written, reads from A000–BFFF return open bus
+If any other value is written, reads from $A000–BFFF return open bus
 values (often $FF, but not guaranteed), and writes are ignored.
 
-### 2000–3FFF – ROM Bank Number (Write-Only)
+### 2000–3FFF — ROM Bank Number [write-only]
 
 HuC-3 can accept a 7-bit bank number here.
 
-### 4000–5FFF – RAM Bank Select (Write-Only)
+### 4000–5FFF — RAM Bank Select [write-only]
 
 HuC-3 can accept a bank number of at least 2 bits here.
 
-### 6000–7FFF – Nothing? (Write-Only)
+### 6000–7FFF — Nothing? [write-only]
 
-Games write $01 here on startup, but it doesn\'t seem to have any
+Games write $01 here on startup, but it doesn’t seem to have any
 observable effect.
 
 
 ## I/O Registers
 
-These registers are accessed by reading or writing int the A000–BFFF
+These registers are accessed by reading or writing int the $A000–BFFF
 range after setting the RAM/RTC/IR Select register. Address lines
 A12–A0 are not connected to the HuC-3 chip, so the offset within the
 range is ignored. Data line D7 is not connected to the HuC-3 chip, so
@@ -73,19 +73,19 @@ ignored.
 
 The RTC MCU communication protocol is described below.
 
-### B – RTC Command/Argument (Write)
+### B — RTC Command/Argument [write]
 
 The value written consists of a command in bits 6-4, and an argument
 value in bits 4–0. For example the value $62 is command $6 with argument
 value $2. Writing to this register just sets the values in the mailbox
 registers – it does not cause the command to be executed.
 
-### C – RTC Command/Response (Read)
+### C — RTC Command/Response [read]
 
 When read, bits 6–4 return the last command written to register $B, and
 bits 3–0 contain the result from the last command executed.
 
-### D – RTC Semaphore (Read/Write)
+### D — RTC Semaphore [read/write]
 
 When reading, the least significant bit is high when the RTC MCU is
 ready to receive a command, or low when the RTC MCU is busy.
@@ -93,7 +93,7 @@ ready to receive a command, or low when the RTC MCU is busy.
 Writing with the least significant bit clear requests that the RTC MCU
 execute the last command written to register $B.
 
-### E – IR (Read/Write)
+### E — IR [read/write]
 
 Similar to the equivalent register of the HuC-1. The least significant
 bit is used for infrared communication.
@@ -102,25 +102,25 @@ bit is used for infrared communication.
 ## RTC Communication Protocol
 
 The HuC-3 chip provides read and write access to a 256-nybble window
-into the RTC MCU\'s internal memory. Multi-nybble values are stored
-with the least significant nybble at the lowest address (little Endian).
+into the RTC MCU’s internal memory. Multi-nybble values are stored with
+the least significant nybble at the lowest address (little Endian).
 There are commands for setting the access address, reading and writing
 values, and a few higher-level operations.
 
 Games use the following sequence to execute a command:
 
 * Write $0D to 0000 (select RTC Semaphore register)
-* Poll A000 until least significant bit is set (wait until ready)
-* Write $0B to 0000 (select RTC Command/Argument register)
+* Poll $A000 until least significant bit is set (wait until ready)
+* Write $0B to $0000 (select RTC Command/Argument register)
 * Write command and argument to A000
-* Write $0D to 0000 (select RTC semaphore register)
-* Write $FE to A000 (clear semaphore, requesting MCU execute command)
-* Poll A000 until least significant bit is set (wait for completion)
-* Write $0C to 0000 (select RTC Command/Response register)
-* Read A000 and use value from 4 least significant bits
+* Write $0D to $0000 (select RTC semaphore register)
+* Write $FE to $A000 (clear semaphore, requesting MCU execute command)
+* Poll $A000 until least significant bit is set (wait for completion)
+* Write $0C to $0000 (select RTC Command/Response register)
+* Read $A000 and use value from 4 least significant bits
 
-(The last two steps are not applicable for commands that don\'t produce
-a response.)
+(The last two steps are not applicable for commands that don’t produce a
+response.)
 
 Known commands:
 
@@ -138,9 +138,9 @@ unknown. Commands $0 and $7 have not been observed.
 The following extended commands have been observed:
 
 Command | Description
---------|------------------------------------------------------------
-  $0    | Copy current time to locations 00–06
-  $1    | Copy locations 00–06 to current time, and update event time
+--------|-------------------------------------------------------------
+  $0    | Copy current time to locations $00–06
+  $1    | Copy locations $00–06 to current time, and update event time
   $2    | Seems to be some kind of status request
   $E    | Executing twice triggers tone generator
 
@@ -157,13 +157,13 @@ The purpose of some locations has been inferred by observing behavior:
 
 Location | Purpose
 ---------|------------------------------------------------------------
-  00–06  | Output or input space for reading or writing current time
-  10–12  | Minute of day counter (rolls over at 1440)
-  13–15  | Day counter
-  26     | Tone selection in two least significant bits
-  27     | Tone generator enabled if value is 1 (all bits checked)
-  58–5A  | Event time minutes
-  5B–5D  | Event time days
+  $00–06 | Output or input space for reading or writing current time
+  $10–12 | Minute of day counter (rolls over at 1440)
+  $13–15 | Day counter
+  $26    | Tone selection in two least significant bits
+  $27    | Tone generator enabled if value is 1 (all bits checked)
+  $58–5A | Event time minutes
+  $5B–5D | Event time days
 
 
 ## External links

--- a/src/HuC3.md
+++ b/src/HuC3.md
@@ -9,7 +9,6 @@ The HuC-3 is poorly understood. Observed behavior suggests the
 real-time clock and tone generator are implemented using a 4-bit
 microcontroller core with internal program ROM.
 
-
 ## Memory
 
 ### 0000–3FFF — ROM Bank 00 [read-only]
@@ -26,7 +25,6 @@ unknown whether bank $00 can be selected here.
 Depending on the current register selection and RAM Bank Number (see
 below), this memory space is used to access an 8 KiB external RAM Bank,
 or a single I/O Register.
-
 
 ## Memory Control Registers
 
@@ -59,7 +57,6 @@ HuC-3 can accept a bank number of at least 2 bits here.
 
 Games write $01 here on startup, but it doesn’t seem to have any
 observable effect.
-
 
 ## I/O Registers
 
@@ -97,7 +94,6 @@ execute the last command written to register $B.
 
 Similar to the equivalent register of the HuC-1. The least significant
 bit is used for infrared communication.
-
 
 ## RTC Communication Protocol
 
@@ -164,7 +160,6 @@ Location | Purpose
   $27    | Tone generator enabled if value is 1 (all bits checked)
   $58–5A | Event time minutes
   $5B–5D | Event time days
-
 
 ## External links
 

--- a/src/HuC3.md
+++ b/src/HuC3.md
@@ -70,19 +70,19 @@ ignored.
 
 The RTC MCU communication protocol is described below.
 
-### B — RTC Command/Argument [write]
+### $B — RTC Command/Argument [write]
 
 The value written consists of a command in bits 6-4, and an argument
 value in bits 4–0. For example the value $62 is command $6 with argument
 value $2. Writing to this register just sets the values in the mailbox
 registers – it does not cause the command to be executed.
 
-### C — RTC Command/Response [read]
+### $C — RTC Command/Response [read]
 
 When read, bits 6–4 return the last command written to register $B, and
 bits 3–0 contain the result from the last command executed.
 
-### D — RTC Semaphore [read/write]
+### $D — RTC Semaphore [read/write]
 
 When reading, the least significant bit is high when the RTC MCU is
 ready to receive a command, or low when the RTC MCU is busy.
@@ -90,9 +90,9 @@ ready to receive a command, or low when the RTC MCU is busy.
 Writing with the least significant bit clear requests that the RTC MCU
 execute the last command written to register $B.
 
-### E — IR [read/write]
+### $E — IR [read/write]
 
-Similar to the equivalent register of the HuC-1. The least significant
+Similar to the equivalent register of the HuC1. The least significant
 bit is used for infrared communication.
 
 ## RTC Communication Protocol
@@ -105,10 +105,10 @@ values, and a few higher-level operations.
 
 Games use the following sequence to execute a command:
 
-* Write $0D to 0000 (select RTC Semaphore register)
+* Write $0D to $0000 (select RTC Semaphore register)
 * Poll $A000 until least significant bit is set (wait until ready)
 * Write $0B to $0000 (select RTC Command/Argument register)
-* Write command and argument to A000
+* Write command and argument to $A000
 * Write $0D to $0000 (select RTC semaphore register)
 * Write $FE to $A000 (clear semaphore, requesting MCU execute command)
 * Poll $A000 until least significant bit is set (wait for completion)

--- a/src/HuC3.md
+++ b/src/HuC3.md
@@ -1,9 +1,9 @@
 # HuC-3
 
-HuC-3 is an MBC used by some Game Boy games which, besides doing the
-usual MBC stuff, also provides a real-time clock, speaker, and infrared
-communication. The CR2025 coin cell is user-replaceable. It is a
-successor to the [HuC1](./HuC1.md).
+HuC-3 is an MBC developed by Hudson Soft. Besides ROM and RAM banking,
+it also provides a real-time clock, speaker, and infrared communication.
+The CR2025 coin cell is user-replaceable. It is a successor to the
+[HuC1](./HuC1.md).
 
 The HuC-3 is poorly understood. Observed behavior suggests the
 real-time clock and tone generator are implemented using a 4-bit

--- a/src/HuC3.md
+++ b/src/HuC3.md
@@ -63,7 +63,7 @@ observable effect.
 
 ## I/O Registers
 
-These registers are accessed by reading or writing int the $A000–BFFF
+These registers are accessed by reading or writing in the $A000–BFFF
 range after setting the RAM/RTC/IR Select register. Address lines
 A12–A0 are not connected to the HuC-3 chip, so the offset within the
 range is ignored. Data line D7 is not connected to the HuC-3 chip, so

--- a/src/MBC5.md
+++ b/src/MBC5.md
@@ -29,10 +29,8 @@ Same as for MBC1, except that RAM sizes are 8 KiB, 32 KiB and 128 KiB.
 Mostly the same as for MBC1. Writing $0A will enable reading and
 writing to external RAM. Writing $00 will disable it.
 
-Actual MBCs actually enable RAM when writing any value whose bottom 4
-bits equal $A (so $0A, $1A, and so on), and disable it when writing
-anything else. Relying on this behavior is not recommended for
-compatibility reasons.
+Actual MBCs actually enable RAM when writing any value whose bottom 4 bits equal $A (so $0A, $1A, and so on), and disable it when writing anything else.
+Relying on this behavior is not recommended for compatibility reasons.
 
 ### 2000-2FFF - 8 least significant bits of ROM bank number (Write Only)
 

--- a/src/MBC5.md
+++ b/src/MBC5.md
@@ -29,8 +29,10 @@ Same as for MBC1, except that RAM sizes are 8 KiB, 32 KiB and 128 KiB.
 Mostly the same as for MBC1. Writing $0A will enable reading and
 writing to external RAM. Writing $00 will disable it.
 
-Actual MBCs actually enable RAM when writing any value whose bottom 4 bits equal $A (so $0A, $1A, and so on), and disable it when writing anything else.
-Relying on this behavior is not recommended for compatibility reasons.
+Actual MBCs actually enable RAM when writing any value whose bottom 4
+bits equal $A (so $0A, $1A, and so on), and disable it when writing
+anything else. Relying on this behavior is not recommended for
+compatibility reasons.
 
 ### 2000-2FFF - 8 least significant bits of ROM bank number (Write Only)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -68,6 +68,7 @@
   - [MMM01](./MMM01.md)
   - [M161](./M161.md)
   - [HuC1](./HuC1.md)
+  - [HuC-3](./HuC3.md)
   - [Other MBCs](./othermbc.md)
 
 # Accessories


### PR DESCRIPTION
This adds preliminary documentation for the HuC-3 combination memory controller, real-time clock, tone generator and infrared communication controller.  Most of the information is already collected in the [cited Gameboy Development Forum thread](https://gbdev.gg8.se/forums/viewtopic.php?id=744) as well as various emulator sources.

I also edited the HuC1 page a little after looking at the contributing guidelines:
* Use `$` as prefix for hexadecimal numbers
* Use no prefix for hexadecimal addresses
* Use en dash rather than hyphen to denote ranges
* Hyphenate “read-only” and “write-only”

The MBC5 page change just wraps a line that stood out as excessively long at 72 columns like the rest of the file seems to use.