### PR TITLE
Plot generation: move to matplotlib, make output SVGs affected by CSS theme

### DIFF
--- a/src/imgs/src/README.md
+++ b/src/imgs/src/README.md
@@ -1,0 +1,7 @@
+# imgs src
+
+This folder contains the source code and the datasets used to generate some plots.
+
+Those plots are included in Pan Docs as normal SVG figures, but their generation is part of pipeline.
+
+The scripts are traditional matplotlib executions but you may notice some additional manipulation on the resulting SVGs to set the lines and text to CSS variables instead of hardcoded colors.


### PR DESCRIPTION
It may seem a bit convoluted, but it works:

https://user-images.githubusercontent.com/14352721/201120995-a3bf61d5-e9f6-472f-ba4a-b150bfb8c9dd.mp4

Some more stuff is needed to merge this but we should be already at a pretty good point:

- [x] move from pygal to matplotlib https://github.com/gbdev/pandocs/issues/449
- [x] make the output SVG use the CSS variables instead of hardcoded colros
- [ ] update requirements.txt
- [ ] move the call to the plot generation from the `renderer` to the `preproc` step of mdbook, otherwise the output SVG files cannot be inline injected
	- We should consider just calling a python script, instead of having the single calls for every plot like it is now [here](https://github.com/gbdev/pandocs/blob/master/book.toml#L16). @ISSOtm opinions?
- [ ] replace the two img tags with #import in the MBC5 article so the svg is actually injected in the HTML

Fixes https://github.com/gbdev/pandocs/issues/322