### PR TITLE
Fix deployment on Windows

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,7 +2,7 @@
 
 This document will explain you how to run a local copy of Pan Docs. 
 
-1. Install [Rust](https://www.rust-lang.org/tools/install), [mdBook](https://github.com/rust-lang/mdBook#readme), and [Python 3](https://www.python.org/downloads).
+1. Install [Rust](https://www.rust-lang.org/tools/install), [mdBook](https://github.com/rust-lang/mdBook#readme), and [Python 3](https://www.python.org/downloads) (3.9 or an earlier version).
   mdBook is the tool rendering the documentation, Rust is used for some custom plugins and Python scripts are used to render some images. E.g.:
   ```sh
   # Install Rust using rustup
@@ -10,7 +10,7 @@ This document will explain you how to run a local copy of Pan Docs.
   # Install mdbook using cargo
   cargo install mdbook
   # Remember to add cargo bin directory to your path
-  # Install Python 3.9 or earlier; for example, on APT-based systems (Ubuntu, Debian...):
+  # Install Python; e.g. on Debian-based systems:
   apt install python3
   ```
 2. [Install the Python prerequisites](https://packaging.python.org/tutorials/installing-packages/#requirements-files).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -10,7 +10,7 @@ This document will explain you how to run a local copy of Pan Docs.
   # Install mdbook using cargo
   cargo install mdbook
   # Remember to add cargo bin directory to your path
-  # Install python3 (on Debian systems)
+  # Install Python 3.9 or earlier; for example, on APT-based systems (Ubuntu, Debian...):
   apt install python3
   ```
 2. [Install the Python prerequisites](https://packaging.python.org/tutorials/installing-packages/#requirements-files).

--- a/renderer/src/main.rs
+++ b/renderer/src/main.rs
@@ -88,7 +88,7 @@ impl Renderer for Pandocs {
         // Generate the graphs in `imgs/src/` by shelling out to Python
         let working_dir = ctx.destination.join("imgs");
         let src_dir = working_dir.join("src");
-        let python = if cfg!(windows) { "py3" } else { "python3" };
+        let python = if cfg!(windows) { "python" } else { "python3" };
         let gen_graph = |file_name, title| {
             let mut file_name = PathBuf::from_str(file_name).unwrap(); // Can't fail
             let output = File::create(working_dir.join(&file_name))?;


### PR DESCRIPTION
On windows the default python3 executable added to Path is not py3 and it depends on the installer.
Microsoft store adds both python and python3 and the official installer adds only python

for more details see #448 