### PR TITLE
Correct SOU_TRN vram data transfer format

### DIFF
--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -50,9 +50,9 @@ All 16-bit values are little-endian.
 
 Data transfer packet format:
 ```
- 000-001  Size of transfer data
- 002-003  Destination address in S-APU RAM (typically $2B00, see below)
- 004-XXX  Data to be transferred
+ 00-01  Size of data below (XX); if zero, this is instead a jump packet
+ 02-03  Destination address in S-APU RAM (typically $2B00, see below)
+ 04-XX  Data to be transferred
 ```
 
 Jump packet format:

--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -57,8 +57,8 @@ Data transfer packet format:
 
 Jump packet format:
 ```
- 000-001  Should be $0000
- 002-003  S-APU jump address, should be $0400 to safely restart the built-in SGB BIOS' N-SPC sound engine
+ 00-01  Must be $0000
+ 02-03  S-APU jump address, use $0400 to safely restart the built-in SGB BIOS' N-SPC sound engine
 ```
 
 Possible destinations in APU-RAM are:

--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -44,16 +44,21 @@ Used to transfer sound code or data to SNES Audio Processing Unit memory
  1-F   Not used (zero)
 ```
 
-The sound code/data is sent by VRAM-Transfer (4 KBytes).
+The sound code/data is sent by VRAM-Transfer (4 KBytes), by optionally specifying some `data transfer` packets from the SNES to its APU, and ending with a `jump` packet.
+
 All 16-bit values are little-endian.
 
+Data transfer packet format:
 ```
  000-001  Size of transfer data
  002-003  Destination address in S-APU RAM (typically $2B00, see below)
  004-XXX  Data to be transferred
- X+1-X+2  "End marker" (???), should be $0000
- X+3-X+4  S-APU jump address, should be $0400
- X+5-FFF  Remaining bytes ignored
+```
+
+Jump packet format:
+```
+ 000-001  Should be $0000
+ 002-003  S-APU jump address, should be $0400 to safely restart the built-in SGB BIOS' N-SPC sound engine
 ```
 
 Possible destinations in APU-RAM are:

--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -52,7 +52,7 @@ Data transfer packet format:
 ```
  0-1    Size of data below (N); if zero, this is instead a jump packet
  2-3    Destination address in S-APU RAM (typically $2B00, see below)
- 4-N+4  Data to be transferred
+ 4-N+3  Data to be transferred
 ```
 
 Jump packet format:

--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -52,7 +52,7 @@ Data transfer packet format:
 ```
  00-01  Size of data below (XX); if zero, this is instead a jump packet
  02-03  Destination address in S-APU RAM (typically $2B00, see below)
- 04-XX  Data to be transferred
+ 04-N+4  Data to be transferred
 ```
 
 Jump packet format:

--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -50,9 +50,9 @@ All 16-bit values are little-endian.
 
 Data transfer packet format:
 ```
- 00-01  Size of data below (XX); if zero, this is instead a jump packet
- 02-03  Destination address in S-APU RAM (typically $2B00, see below)
- 04-N+4  Data to be transferred
+ 0-1    Size of data below (N); if zero, this is instead a jump packet
+ 2-3    Destination address in S-APU RAM (typically $2B00, see below)
+ 4-N+4  Data to be transferred
 ```
 
 Jump packet format:

--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -44,7 +44,7 @@ Used to transfer sound code or data to SNES Audio Processing Unit memory
  1-F   Not used (zero)
 ```
 
-The sound code/data is sent by VRAM-Transfer (4 KBytes), by optionally specifying some `data transfer` packets from the SNES to its APU, and ending with a `jump` packet.
+The sound code/data is sent by [VRAM transfer](<#VRAM Transfers>) as a contiguous list of "packets".
 
 All 16-bit values are little-endian.
 

--- a/src/SGB_Command_Sound.md
+++ b/src/SGB_Command_Sound.md
@@ -57,8 +57,8 @@ Data transfer packet format:
 
 Jump packet format:
 ```
- 00-01  Must be $0000
- 02-03  S-APU jump address, use $0400 to safely restart the built-in SGB BIOS' N-SPC sound engine
+ 0-1  Must be $0000
+ 2-3  S-APU jump address, use $0400 to safely restart the built-in SGB BIOS' N-SPC sound engine
 ```
 
 Possible destinations in APU-RAM are:


### PR DESCRIPTION
Clear up that there can be >1 data transfer packet