### PR TITLE
fix typo in LCD mode timing description

### DIFF
--- a/src/STAT.md
+++ b/src/STAT.md
@@ -51,10 +51,10 @@ to the CPU: writes are ignored, and reads return garbage values (usually $FF).
 
 Mode | Action                                                      | Duration                                                           | Accessible video memory
 -----|------------------------------------------------------------------|--------------------------------------------------------------------|-------------------------
-  2  | Searching OAM for OBJs whose Y coordinate overlap this line | 80 dots                                                    | VRAM, CGB palettes
+  2  | Searching OAM for OBJs whose Y coordinate overlap this line | 80 dots                                               | VRAM, CGB palettes
   3  | Reading OAM and VRAM to generate the picture                | 168 to 291 dots, depending on sprite count            | None
-  0  | Nothing (HBlank)                               | 85 to 208 dots, depending on previous mode 3 duration | VRAM, OAM, CGB palettes
-  1  | Nothing (VBlank)                                 | 4560 dots (10 scanlines)                                  | VRAM, OAM, CGB palettes
+  0  | Nothing (HBlank)                                            | 85 to 208 dots, depending on previous mode 3 duration | VRAM, OAM, CGB palettes
+  1  | Nothing (VBlank)                                            | 4560 dots (10 scanlines)                              | VRAM, OAM, CGB palettes
 
 ## Properties of STAT modes
 

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -52,7 +52,7 @@ to the CPU: writes are ignored, and reads return garbage values (usually $FF).
 Mode | Action                                                      | Duration                                                           | Accessible video memory
 -----|------------------------------------------------------------------|--------------------------------------------------------------------|-------------------------
   2  | Searching OAM for OBJs whose Y coordinate overlap this line | 80 dots (19 µs)                                                    | VRAM, CGB palettes
-  3  | Reading OAM and VRAM to generate the picture                | 168 to 291 dots (40 to 60 µs) depending on sprite count            | None
+  3  | Reading OAM and VRAM to generate the picture                | 168 to 291 dots (40 to 69 µs) depending on sprite count            | None
   0  | Nothing (HBlank)                               | 85 to 208 dots (20 to 49 µs) depending on previous mode 3 duration | VRAM, OAM, CGB palettes
   1  | Nothing (VBlank)                                 | 4560 dots (1087 µs, 10 scanlines)                                  | VRAM, OAM, CGB palettes
 

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -51,10 +51,10 @@ to the CPU: writes are ignored, and reads return garbage values (usually $FF).
 
 Mode | Action                                                      | Duration                                                           | Accessible video memory
 -----|------------------------------------------------------------------|--------------------------------------------------------------------|-------------------------
-  2  | Searching OAM for OBJs whose Y coordinate overlap this line | 80 dots (19 µs)                                                    | VRAM, CGB palettes
-  3  | Reading OAM and VRAM to generate the picture                | 168 to 291 dots (40 to 69 µs) depending on sprite count            | None
-  0  | Nothing (HBlank)                               | 85 to 208 dots (20 to 49 µs) depending on previous mode 3 duration | VRAM, OAM, CGB palettes
-  1  | Nothing (VBlank)                                 | 4560 dots (1087 µs, 10 scanlines)                                  | VRAM, OAM, CGB palettes
+  2  | Searching OAM for OBJs whose Y coordinate overlap this line | 80 dots                                                    | VRAM, CGB palettes
+  3  | Reading OAM and VRAM to generate the picture                | 168 to 291 dots, depending on sprite count            | None
+  0  | Nothing (HBlank)                               | 85 to 208 dots, depending on previous mode 3 duration | VRAM, OAM, CGB palettes
+  1  | Nothing (VBlank)                                 | 4560 dots (10 scanlines)                                  | VRAM, OAM, CGB palettes
 
 ## Properties of STAT modes
 


### PR DESCRIPTION
the microsecond estimates for mode timings didn't line up. presumably HBlank is intended to pad times for each line at a consistent 376 dots, and adding minimum mode 3 + maximum mode 0 equals maximum mode 3 + minimum mode 0 - 376  dots either way. but the microsecond estimates didn't match: 60 + 20 = 80µs vs 40 + 49 = 89µs.

presumably the correct µs estimates for mode 3 are "(40 to 69µs)":
```
>> 291 / (2 ** 22) * 1000 * 1000
> 69.38 (microseconds)
```

correcting this value makes the min/max sums of mode 3/mode 0 times consistently 89µs, which is almost the same as the time for 376 dots:
```
>> 376 / (2 ** 22) * 1000 * 1000
> 89.65
```

(i also spot-checked the other numbers in this table and everything else lines up)

((also thank you all very much for these documents!!))