### PR TITLE
Add a page with a table list of hardware regs

### DIFF
--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -1,67 +1,67 @@
 
 # Hardware Registers
 
-| Addr       | Name                                                   | Description                                                       | R/W |
-|:-----------|--------------------------------------------------------|-------------------------------------------------------------------|-----|
-| $FF00      | [P1/JOYP][P1/JOYP]                                     | Joypad                                                            | R/W |
-| $FF01      | [SB][SB]                                               | Serial transfer data                                              | R/W |
-| $FF02      | [SC][SC]                                               | Serial transfer control                                           | R/W |
-| $FF04      | [DIV][DIV]                                             | Divider register                                                  | R/W |
-| $FF05      | [TIMA][TIMA]                                           | Timer counter                                                     | R/W |
-| $FF06      | [TMA][TMA]                                             | Timer modulo                                                      | R/W |
-| $FF07      | [TAC][TAC]                                             | Timer control                                                     | R/W |
-| $FF0F      | [IF][IF]                                               | Interrupt flag                                                    | R/W |
-| $FF10      | [NR10][NR10]                                           | Channel 1 sweep                                                   | R/W |
-| $FF11      | [NR11][NR11]                                           | Channel 1 length timer & duty cycle                               | R/W |
-| $FF12      | [NR12][NR12]                                           | Channel 1 volume & envelope                                       | R/W |
-| $FF13      | [NR13][NR13]                                           | Channel 1 wavelength low                                          | W   |
-| $FF14      | [NR14][NR14]                                           | Channel 1 wavelength high & control                               | R/W |
-| $FF16      | [NR21][NR21]                                           | Channel 2 length timer & duty cycle                               | R/W |
-| $FF17      | [NR22][NR22]                                           | Channel 2 volume & envelope                                       | R/W |
-| $FF18      | [NR23][NR23]                                           | Channel 2 wavelength low                                          | W   |
-| $FF19      | [NR24][NR24]                                           | Channel 2 wavelength high & control                               | R/W |
-| $FF1A      | [NR30][NR30]                                           | Channel 3 DAC enable                                              | R/W |
-| $FF1B      | [NR31][NR31]                                           | Channel 3 length timer                                            | W   |
-| $FF1C      | [NR32][NR32]                                           | Channel 3 output level                                            | R/W |
-| $FF1D      | [NR33][NR33]                                           | Channel 3 wavelength low                                          | W   |
-| $FF1E      | [NR34][NR34]                                           | Channel 3 wavelength high & control                               | R/W |
-| $FF20      | [NR41][NR41]                                           | Channel 4 length timer                                            | W   |
-| $FF21      | [NR42][NR42]                                           | Channel 4 volume & envelope                                       | R/W |
-| $FF22      | [NR43][NR43]                                           | Channel 4 frequency & randomness                                  | R/W |
-| $FF23      | [NR44][NR44]                                           | Channel 4 control                                                 | R/W |
-| $FF24      | [NR50][NR50]                                           | Master volume & VIN panning                                       | R/W |
-| $FF25      | [NR51][NR51]                                           | Sound panning                                                     | R/W |
-| $FF26      | [NR52][NR52]                                           | Sound on/off                                                      | R/W |
-| $FF30-FF3F | [Wave pattern ram][Wave pattern ram]                   | Wave pattern RAM                                                  | R/W |
-| $FF40      | [LCDC][LCDC]                                           | LCD control                                                       | R/W |
-| $FF41      | [STAT][STAT]                                           | LCD status                                                        | R/W |
-| $FF42      | [SCY][SCY]                                             | Viewport Y position                                               | R/W |
-| $FF43      | [SCX][SCX]                                             | Viewport X position                                               | R/W |
-| $FF44      | [LY][LY]                                               | LCD Y coordinate                                                  | R   |
-| $FF45      | [LYC][LYC]                                             | LY compare                                                        | R/W |
-| $FF46      | [DMA][DMA]                                             | OAM DMA source address & start                                    | R/W |
-| $FF47      | [BGP (Non-CGB Mode only)][BGP (Non-CGB Mode only)]     | BG palette data                                                   | R/W |
-| $FF48      | [OBP0 (Non-CGB Mode only)][OBP0 (Non-CGB Mode only)]   | OBJ palette 0 data                                                | R/W |
-| $FF49      | [OBP1 (Non-CGB Mode only)][OBP1 (Non-CGB Mode only)]   | OBJ palette 1 data                                                | R/W |
-| $FF4A      | [WY][WY]                                               | Window Y position                                                 | R/W |
-| $FF4B      | [WX][WX]                                               | Window X position plus 7                                          | R/W |
-| $FF4D      | [KEY1 (CGB Mode only)][KEY1 (CGB Mode only)]           | Prepare speed switch                                              | R/W |
-| $FF4F      | [VBK (CGB Mode only)][VBK (CGB Mode only)]             | VRAM bank                                                         | R/W |
-| $FF51      | [HDMA1 (CGB Mode only)][HDMA1 (CGB Mode only)]         | VRAM DMA source high                                              | W   |
-| $FF52      | [HDMA2 (CGB Mode only)][HDMA2 (CGB Mode only)]         | VRAM DMA source low                                               | W   |
-| $FF53      | [HDMA3 (CGB Mode only)][HDMA3 (CGB Mode only)]         | VRAM DMA destination high                                         | W   |
-| $FF54      | [HDMA4 (CGB Mode only)][HDMA4 (CGB Mode only)]         | VRAM DMA destination low                                          | W   |
-| $FF55      | [HDMA5 (CGB Mode only)][HDMA5 (CGB Mode only)]         | VRAM DMA length/mode/start                                        | R/W |
-| $FF56      | [RP (CGB Mode only)][RP (CGB Mode only)]               | Infrared communications port                                      | R/W |
-| $FF68      | [BCPS/BGPI (CGB Mode only)][BCPS/BGPI (CGB Mode only)] | Background color palette specification / Background palette index | R/W |
-| $FF69      | [BCPD/BGPD (CGB Mode only)][BCPD/BGPD (CGB Mode only)] | Background color palette data / Background palette data           | R/W |
-| $FF6A      | [OCPS/OBPI (CGB Mode only)][OCPS/OBPI (CGB Mode only)] | OBJ color palette specification / OBJ palette index               | R/W |
-| $FF6B      | [OCPD/OBPD (CGB Mode only)][OCPD/OBPD (CGB Mode only)] | OBJ color palette data / OBJ palette data                         | R/W |
-| $FF6C      | [OPRI (CGB Mode only)][OPRI (CGB Mode only)]           | Object priority mode                                              | R/W |
-| $FF70      | [SVBK (CGB Mode only)][SVBK (CGB Mode only)]           | WRAM bank                                                         | R/W |
-| $FF76      | [PCM12 (CGB Mode only)][PCM12 (CGB Mode only)]         | Digital outputs 1 & 2                                             | R   |
-| $FF77      | [PCM34 (CGB Mode only)][PCM34 (CGB Mode only)]         | Digital outputs 3 & 4                                             | R   |
-| $FFFF      | [IE][IE]                                               | Interrupt enable                                                  | R/W |
+Address    | Name                        | Description                                                       | Readable / Writable
+:----------|-----------------------------|-------------------------------------------------------------------|----
+$FF00      | [P1/JOYP]                   | Joypad                                                            | R/W
+$FF01      | [SB]                        | Serial transfer data                                              | R/W
+$FF02      | [SC]                        | Serial transfer control                                           | R/W
+$FF04      | [DIV]                       | Divider register                                                  | R/W
+$FF05      | [TIMA]                      | Timer counter                                                     | R/W
+$FF06      | [TMA]                       | Timer modulo                                                      | R/W
+$FF07      | [TAC]                       | Timer control                                                     | R/W
+$FF0F      | [IF]                        | Interrupt flag                                                    | R/W
+$FF10      | [NR10]                      | Channel 1 sweep                                                   | R/W
+$FF11      | [NR11]                      | Channel 1 length timer & duty cycle                               | R/W
+$FF12      | [NR12]                      | Channel 1 volume & envelope                                       | R/W
+$FF13      | [NR13]                      | Channel 1 wavelength low                                          | W  
+$FF14      | [NR14]                      | Channel 1 wavelength high & control                               | R/W
+$FF16      | [NR21]                      | Channel 2 length timer & duty cycle                               | R/W
+$FF17      | [NR22]                      | Channel 2 volume & envelope                                       | R/W
+$FF18      | [NR23]                      | Channel 2 wavelength low                                          | W  
+$FF19      | [NR24]                      | Channel 2 wavelength high & control                               | R/W
+$FF1A      | [NR30]                      | Channel 3 DAC enable                                              | R/W
+$FF1B      | [NR31]                      | Channel 3 length timer                                            | W  
+$FF1C      | [NR32]                      | Channel 3 output level                                            | R/W
+$FF1D      | [NR33]                      | Channel 3 wavelength low                                          | W  
+$FF1E      | [NR34]                      | Channel 3 wavelength high & control                               | R/W
+$FF20      | [NR41]                      | Channel 4 length timer                                            | W  
+$FF21      | [NR42]                      | Channel 4 volume & envelope                                       | R/W
+$FF22      | [NR43]                      | Channel 4 frequency & randomness                                  | R/W
+$FF23      | [NR44]                      | Channel 4 control                                                 | R/W
+$FF24      | [NR50]                      | Master volume & VIN panning                                       | R/W
+$FF25      | [NR51]                      | Sound panning                                                     | R/W
+$FF26      | [NR52]                      | Sound on/off                                                      | R/W
+$FF30-FF3F | [Wave pattern ram]          | Wave pattern RAM                                                  | R/W
+$FF40      | [LCDC]                      | LCD control                                                       | R/W
+$FF41      | [STAT]                      | LCD status                                                        | R/W
+$FF42      | [SCY]                       | Viewport Y position                                               | R/W
+$FF43      | [SCX]                       | Viewport X position                                               | R/W
+$FF44      | [LY]                        | LCD Y coordinate                                                  | R  
+$FF45      | [LYC]                       | LY compare                                                        | R/W
+$FF46      | [DMA]                       | OAM DMA source address & start                                    | R/W
+$FF47      | [BGP (Non-CGB Mode only)]   | BG palette data                                                   | R/W
+$FF48      | [OBP0 (Non-CGB Mode only)]  | OBJ palette 0 data                                                | R/W
+$FF49      | [OBP1 (Non-CGB Mode only)]  | OBJ palette 1 data                                                | R/W
+$FF4A      | [WY]                        | Window Y position                                                 | R/W
+$FF4B      | [WX]                        | Window X position plus 7                                          | R/W
+$FF4D      | [KEY1 (CGB Mode only)]      | Prepare speed switch                                              | R/W
+$FF4F      | [VBK (CGB Mode only)]       | VRAM bank                                                         | R/W
+$FF51      | [HDMA1 (CGB Mode only)]     | VRAM DMA source high                                              | W  
+$FF52      | [HDMA2 (CGB Mode only)]     | VRAM DMA source low                                               | W  
+$FF53      | [HDMA3 (CGB Mode only)]     | VRAM DMA destination high                                         | W  
+$FF54      | [HDMA4 (CGB Mode only)]     | VRAM DMA destination low                                          | W  
+$FF55      | [HDMA5 (CGB Mode only)]     | VRAM DMA length/mode/start                                        | R/W
+$FF56      | [RP (CGB Mode only)]        | Infrared communications port                                      | R/W
+$FF68      | [BCPS/BGPI (CGB Mode only)] | Background color palette specification / Background palette index | R/W
+$FF69      | [BCPD/BGPD (CGB Mode only)] | Background color palette data / Background palette data           | R/W
+$FF6A      | [OCPS/OBPI (CGB Mode only)] | OBJ color palette specification / OBJ palette index               | R/W
+$FF6B      | [OCPD/OBPD (CGB Mode only)] | OBJ color palette data / OBJ palette data                         | R/W
+$FF6C      | [OPRI (CGB Mode only)]      | Object priority mode                                              | R/W
+$FF70      | [SVBK (CGB Mode only)]      | WRAM bank                                                         | R/W
+$FF76      | [PCM12 (CGB Mode only)]     | Digital outputs 1 & 2                                             | R  
+$FF77      | [PCM34 (CGB Mode only)]     | Digital outputs 3 & 4                                             | R  
+$FFFF      | [IE]                        | Interrupt enable                                                  | R/W
 
 [P1/JOYP]: <#FF00 — P1/JOYP: Joypad>
 [SB]: <#FF01 — SB: Serial transfer data>

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -1,369 +1,123 @@
 
 # Hardware Registers
 
-<table>
-  <thead>
-    <tr>
-      <th>Addr</th>
-      <th>Name</th>
-      <th>Description</th>
-      <th>R/W</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>$FF00</td>
-      <td><a href="./Joypad_Input.html#ff00--p1joyp-joypad">P1/JOYP</a></td>
-      <td>Joypad</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF01</td>
-      <td><a href="./Serial_Data_Transfer_(Link_Cable).html#ff01--sb-serial-transfer-data">SB</a></td>
-      <td>Serial transfer data</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF02</td>
-      <td><a href="./Serial_Data_Transfer_(Link_Cable).html#ff02--sc-serial-transfer-control">SC</a></td>
-      <td>Serial transfer control</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF04</td>
-      <td><a href="./Timer_and_Divider_Registers.html#ff04--div-divider-register">DIV</a></td>
-      <td>Divider register</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF05</td>
-      <td><a href="./Timer_and_Divider_Registers.html#ff05--tima-timer-counter">TIMA</a></td>
-      <td>Timer counter</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF06</td>
-      <td><a href="./Timer_and_Divider_Registers.html#ff06--tma-timer-modulo">TMA</a></td>
-      <td>Timer modulo</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF07</td>
-      <td><a href="./Timer_and_Divider_Registers.html#ff07--tac-timer-control">TAC</a></td>
-      <td>Timer control</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF0F</td>
-      <td><a href="./Interrupts.html#ff0f--if-interrupt-flag">IF</a></td>
-      <td>Interrupt flag</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF10</td>
-      <td><a href="./Audio_Registers.html#ff10--nr10-channel-1-sweep">NR10</a></td>
-      <td>Channel 1 sweep</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF11</td>
-      <td><a href="./Audio_Registers.html#ff11--nr11-channel-1-length-timer--duty-cycle">NR11</a></td>
-      <td>Channel 1 length timer & duty cycle</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF12</td>
-      <td><a href="./Audio_Registers.html#ff12--nr12-channel-1-volume--envelope">NR12</a></td>
-      <td>Channel 1 volume & envelope</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF13</td>
-      <td><a href="./Audio_Registers.html#ff13--nr13-channel-1-wavelength-low-write-only">NR13</a></td>
-      <td>Channel 1 wavelength low</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF14</td>
-      <td><a href="./Audio_Registers.html#ff14--nr14-channel-1-wavelength-high--control">NR14</a></td>
-      <td>Channel 1 wavelength high & control</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF16</td>
-      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR21</a></td>
-      <td>Channel 2 length timer & duty cycle</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF17</td>
-      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR22</a></td>
-      <td>Channel 2 volume & envelope</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF18</td>
-      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR23</a></td>
-      <td>Channel 2 wavelength low</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF19</td>
-      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR24</a></td>
-      <td>Channel 2 wavelength high & control</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF1A</td>
-      <td><a href="./Audio_Registers.html#ff1a--nr30-channel-3-dac-enable">NR30</a></td>
-      <td>Channel 3 DAC enable</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF1B</td>
-      <td><a href="./Audio_Registers.html#ff1b--nr31-channel-3-length-timer-write-only">NR31</a></td>
-      <td>Channel 3 length timer</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF1C</td>
-      <td><a href="./Audio_Registers.html#ff1c--nr32-channel-3-output-level">NR32</a></td>
-      <td>Channel 3 output level</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF1D</td>
-      <td><a href="./Audio_Registers.html#ff1d--nr33-channel-3-wavelength-low-write-only">NR33</a></td>
-      <td>Channel 3 wavelength low</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF1E</td>
-      <td><a href="./Audio_Registers.html#ff1e--nr34-channel-3-wavelength-high--control">NR34</a></td>
-      <td>Channel 3 wavelength high & control</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF20</td>
-      <td><a href="./Audio_Registers.html#ff20--nr41-channel-4-length-timer-write-only">NR41</a></td>
-      <td>Channel 4 length timer</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF21</td>
-      <td><a href="./Audio_Registers.html#ff21--nr42-channel-4-volume--envelope">NR42</a></td>
-      <td>Channel 4 volume & envelope</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF22</td>
-      <td><a href="./Audio_Registers.html#ff22--nr43-channel-4-frequency--randomness">NR43</a></td>
-      <td>Channel 4 frequency & randomness</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF23</td>
-      <td><a href="./Audio_Registers.html#ff23--nr44-channel-4-control">NR44</a></td>
-      <td>Channel 4 control</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF24</td>
-      <td><a href="./Audio_Registers.html#ff24--nr50-master-volume--vin-panning">NR50</a></td>
-      <td>Master volume & VIN panning</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF25</td>
-      <td><a href="./Audio_Registers.html#ff25--nr51-sound-panning">NR51</a></td>
-      <td>Sound panning</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF26</td>
-      <td><a href="./Audio_Registers.html#ff26--nr52-sound-onoff">NR52</a></td>
-      <td>Sound on/off</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF30-FF3F</td>
-      <td><a href="./Audio_Registers.html#ff30ff3f--wave-pattern-ram"></a></td>
-      <td>Wave pattern RAM</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF40</td>
-      <td><a href="./LCDC.html#ff40--lcdc-lcd-control">LCDC</a></td>
-      <td>LCD control</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF41</td>
-      <td><a href="./STAT.html#ff41--stat-lcd-status">STAT</a></td>
-      <td>LCD status</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF42</td>
-      <td><a href="./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position">SCY</a></td>
-      <td>Viewport Y position</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF43</td>
-      <td><a href="./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position">SCX</a></td>
-      <td>Viewport X position</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF44</td>
-      <td><a href="./Scrolling.html#ff44--ly-lcd-y-coordinate-read-only">LY</a></td>
-      <td>LCD Y coordinate</td>
-      <td>R</td>
-    </tr>
-    <tr>
-      <td>$FF45</td>
-      <td><a href="./Scrolling.html#ff45--lyc-ly-compare">LYC</a></td>
-      <td>LY compare</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF46</td>
-      <td><a href="./OAM_DMA_Transfer.html#ff46--dma-oam-dma-source-address--start">DMA</a></td>
-      <td>OAM DMA source address & start</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF47</td>
-      <td><a href="./Palettes.html#ff47--bgp-non-cgb-mode-only-bg-palette-data">BGP (Non-CGB Mode only)</a></td>
-      <td>BG palette data</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF48</td>
-      <td><a href="./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data">OBP0 (Non-CGB Mode only)</a></td>
-      <td>OBJ palette 0 data</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF49</td>
-      <td><a href="./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data">OBP1 (Non-CGB Mode only)</a></td>
-      <td>OBJ palette 1 data</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF4A</td>
-      <td><a href="./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7">WY</a></td>
-      <td>Window Y position</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF4B</td>
-      <td><a href="./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7">WX</a></td>
-      <td>Window X position plus 7</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF4D</td>
-      <td><a href="./CGB_Registers.html#ff4d--key1-cgb-mode-only-prepare-speed-switch">KEY1 (CGB Mode only)</a></td>
-      <td>Prepare speed switch</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF4F</td>
-      <td><a href="./CGB_Registers.html#ff4f--vbk-cgb-mode-only-vram-bank">VBK (CGB Mode only)</a></td>
-      <td>VRAM bank</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF51</td>
-      <td><a href="./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only">HDMA1 (CGB Mode only)</a></td>
-      <td>VRAM DMA source high</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF52</td>
-      <td><a href="./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only">HDMA2 (CGB Mode only)</a></td>
-      <td>VRAM DMA source low</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF53</td>
-      <td><a href="./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only">HDMA3 (CGB Mode only)</a></td>
-      <td>VRAM DMA destination high</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF54</td>
-      <td><a href="./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only">HDMA4 (CGB Mode only)</a></td>
-      <td>VRAM DMA destination low</td>
-      <td>W</td>
-    </tr>
-    <tr>
-      <td>$FF55</td>
-      <td><a href="./CGB_Registers.html#ff55--hdma5-cgb-mode-only-vram-dma-lengthmodestart">HDMA5 (CGB Mode only)</a></td>
-      <td>VRAM DMA length/mode/start</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF56</td>
-      <td><a href="./CGB_Registers.html#ff56--rp-cgb-mode-only-infrared-communications-port">RP (CGB Mode only)</a></td>
-      <td>Infrared communications port</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF68</td>
-      <td><a href="./Palettes.html#ff68--bcpsbgpi-cgb-mode-only-background-color-palette-specification--background-palette-index">BCPS/BGPI (CGB Mode only)</a></td>
-      <td>Background color palette specification / Background palette index</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF69</td>
-      <td><a href="./Palettes.html#ff69--bcpdbgpd-cgb-mode-only-background-color-palette-data--background-palette-data">BCPD/BGPD (CGB Mode only)</a></td>
-      <td>Background color palette data / Background palette data</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF6A</td>
-      <td><a href="./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data">OCPS/OBPI (CGB Mode only)</a></td>
-      <td>OBJ color palette specification / OBJ palette index</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF6B</td>
-      <td><a href="./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data">OCPD/OBPD (CGB Mode only)</a></td>
-      <td>OBJ color palette data / OBJ palette data</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF6C</td>
-      <td><a href="./CGB_Registers.html#ff6c--opri-cgb-mode-only-object-priority-mode">OPRI (CGB Mode only)</a></td>
-      <td>Object priority mode</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF70</td>
-      <td><a href="./CGB_Registers.html#ff70--svbk-cgb-mode-only-wram-bank">SVBK (CGB Mode only)</a></td>
-      <td>WRAM bank</td>
-      <td>R/W</td>
-    </tr>
-    <tr>
-      <td>$FF76</td>
-      <td><a href="./Audio_details.html#ff76--pcm12-cgb-mode-only-digital-outputs-1--2-read-only">PCM12 (CGB Mode only)</a></td>
-      <td>Digital outputs 1 & 2</td>
-      <td>R</td>
-    </tr>
-    <tr>
-      <td>$FF77</td>
-      <td><a href="./Audio_details.html#ff77--pcm34-cgb-mode-only-digital-outputs-3--4-read-only">PCM34 (CGB Mode only)</a></td>
-      <td>Digital outputs 3 & 4</td>
-      <td>R</td>
-    </tr>
-    <tr>
-      <td>$FFFF</td>
-      <td><a href="./Interrupts.html#ffff--ie-interrupt-enable">IE</a></td>
-      <td>Interrupt enable</td>
-      <td>R/W</td>
-    </tr>
-  </tbody>
-</table>
+| Addr       | Name                                                       | Description                                                       | R/W |
+|:-----------|------------------------------------------------------------|-------------------------------------------------------------------|-----|
+| $FF01      | [SB][linkSB]                                               | Serial transfer data                                              | R/W |
+| $FF02      | [SC][linkSC]                                               | Serial transfer control                                           | R/W |
+| $FF04      | [DIV][linkDIV]                                             | Divider register                                                  | R/W |
+| $FF05      | [TIMA][linkTIMA]                                           | Timer counter                                                     | R/W |
+| $FF06      | [TMA][linkTMA]                                             | Timer modulo                                                      | R/W |
+| $FF07      | [TAC][linkTAC]                                             | Timer control                                                     | R/W |
+| $FF0F      | [IF][linkIF]                                               | Interrupt flag                                                    | R/W |
+| $FF10      | [NR10][linkNR10]                                           | Channel 1 sweep                                                   | R/W |
+| $FF11      | [NR11][linkNR11]                                           | Channel 1 length timer & duty cycle                               | R/W |
+| $FF12      | [NR12][linkNR12]                                           | Channel 1 volume & envelope                                       | R/W |
+| $FF13      | [NR13][linkNR13]                                           | Channel 1 wavelength low                                          | W   |
+| $FF14      | [NR14][linkNR14]                                           | Channel 1 wavelength high & control                               | R/W |
+| $FF16      | [NR21][linkNR21]                                           | Channel 2 length timer & duty cycle                               | R/W |
+| $FF17      | [NR22][linkNR22]                                           | Channel 2 volume & envelope                                       | R/W |
+| $FF18      | [NR23][linkNR23]                                           | Channel 2 wavelength low                                          | W   |
+| $FF19      | [NR24][linkNR24]                                           | Channel 2 wavelength high & control                               | R/W |
+| $FF1A      | [NR30][linkNR30]                                           | Channel 3 DAC enable                                              | R/W |
+| $FF1B      | [NR31][linkNR31]                                           | Channel 3 length timer                                            | W   |
+| $FF1C      | [NR32][linkNR32]                                           | Channel 3 output level                                            | R/W |
+| $FF1D      | [NR33][linkNR33]                                           | Channel 3 wavelength low                                          | W   |
+| $FF1E      | [NR34][linkNR34]                                           | Channel 3 wavelength high & control                               | R/W |
+| $FF20      | [NR41][linkNR41]                                           | Channel 4 length timer                                            | W   |
+| $FF21      | [NR42][linkNR42]                                           | Channel 4 volume & envelope                                       | R/W |
+| $FF22      | [NR43][linkNR43]                                           | Channel 4 frequency & randomness                                  | R/W |
+| $FF23      | [NR44][linkNR44]                                           | Channel 4 control                                                 | R/W |
+| $FF24      | [NR50][linkNR50]                                           | Master volume & VIN panning                                       | R/W |
+| $FF25      | [NR51][linkNR51]                                           | Sound panning                                                     | R/W |
+| $FF26      | [NR52][linkNR52]                                           | Sound on/off                                                      | R/W |
+| $FF30-FF3F | [Wave pattern ram][linkWave pattern ram]                   | Wave pattern RAM                                                  | R/W |
+| $FF40      | [LCDC][linkLCDC]                                           | LCD control                                                       | R/W |
+| $FF41      | [STAT][linkSTAT]                                           | LCD status                                                        | R/W |
+| $FF42      | [SCY][linkSCY]                                             | Viewport Y position                                               | R/W |
+| $FF43      | [SCX][linkSCX]                                             | Viewport X position                                               | R/W |
+| $FF44      | [LY][linkLY]                                               | LCD Y coordinate                                                  | R   |
+| $FF45      | [LYC][linkLYC]                                             | LY compare                                                        | R/W |
+| $FF46      | [DMA][linkDMA]                                             | OAM DMA source address & start                                    | R/W |
+| $FF47      | [BGP (Non-CGB Mode only)][linkBGP (Non-CGB Mode only)]     | BG palette data                                                   | R/W |
+| $FF48      | [OBP0 (Non-CGB Mode only)][linkOBP0 (Non-CGB Mode only)]   | OBJ palette 0 data                                                | R/W |
+| $FF49      | [OBP1 (Non-CGB Mode only)][linkOBP1 (Non-CGB Mode only)]   | OBJ palette 1 data                                                | R/W |
+| $FF4A      | [WY][linkWY]                                               | Window Y position                                                 | R/W |
+| $FF4B      | [WX][linkWX]                                               | Window X position plus 7                                          | R/W |
+| $FF4D      | [KEY1 (CGB Mode only)][linkKEY1 (CGB Mode only)]           | Prepare speed switch                                              | R/W |
+| $FF4F      | [VBK (CGB Mode only)][linkVBK (CGB Mode only)]             | VRAM bank                                                         | R/W |
+| $FF51      | [HDMA1 (CGB Mode only)][linkHDMA1 (CGB Mode only)]         | VRAM DMA source high                                              | W   |
+| $FF52      | [HDMA2 (CGB Mode only)][linkHDMA2 (CGB Mode only)]         | VRAM DMA source low                                               | W   |
+| $FF53      | [HDMA3 (CGB Mode only)][linkHDMA3 (CGB Mode only)]         | VRAM DMA destination high                                         | W   |
+| $FF54      | [HDMA4 (CGB Mode only)][linkHDMA4 (CGB Mode only)]         | VRAM DMA destination low                                          | W   |
+| $FF55      | [HDMA5 (CGB Mode only)][linkHDMA5 (CGB Mode only)]         | VRAM DMA length/mode/start                                        | R/W |
+| $FF56      | [RP (CGB Mode only)][linkRP (CGB Mode only)]               | Infrared communications port                                      | R/W |
+| $FF68      | [BCPS/BGPI (CGB Mode only)][linkBCPS/BGPI (CGB Mode only)] | Background color palette specification / Background palette index | R/W |
+| $FF69      | [BCPD/BGPD (CGB Mode only)][linkBCPD/BGPD (CGB Mode only)] | Background color palette data / Background palette data           | R/W |
+| $FF6A      | [OCPS/OBPI (CGB Mode only)][linkOCPS/OBPI (CGB Mode only)] | OBJ color palette specification / OBJ palette index               | R/W |
+| $FF6B      | [OCPD/OBPD (CGB Mode only)][linkOCPD/OBPD (CGB Mode only)] | OBJ color palette data / OBJ palette data                         | R/W |
+| $FF6C      | [OPRI (CGB Mode only)][linkOPRI (CGB Mode only)]           | Object priority mode                                              | R/W |
+| $FF70      | [SVBK (CGB Mode only)][linkSVBK (CGB Mode only)]           | WRAM bank                                                         | R/W |
+| $FF76      | [PCM12 (CGB Mode only)][linkPCM12 (CGB Mode only)]         | Digital outputs 1 & 2                                             | R   |
+| $FF77      | [PCM34 (CGB Mode only)][linkPCM34 (CGB Mode only)]         | Digital outputs 3 & 4                                             | R   |
+| $FFFF      | [IE][linkIE]                                               | Interrupt enable                                                  | R/W |
+
+
+[linkSB]: ./Serial_Data_Transfer_(Link_Cable).html#ff01--sb-serial-transfer-data
+[linkSC]: ./Serial_Data_Transfer_(Link_Cable).html#ff02--sc-serial-transfer-control
+[linkDIV]: ./Timer_and_Divider_Registers.html#ff04--div-divider-register
+[linkTIMA]: ./Timer_and_Divider_Registers.html#ff05--tima-timer-counter
+[linkTMA]: ./Timer_and_Divider_Registers.html#ff06--tma-timer-modulo
+[linkTAC]: ./Timer_and_Divider_Registers.html#ff07--tac-timer-control
+[linkIF]: ./Interrupts.html#ff0f--if-interrupt-flag
+[linkNR10]: ./Audio_Registers.html#ff10--nr10-channel-1-sweep
+[linkNR11]: ./Audio_Registers.html#ff11--nr11-channel-1-length-timer--duty-cycle
+[linkNR12]: ./Audio_Registers.html#ff12--nr12-channel-1-volume--envelope
+[linkNR13]: ./Audio_Registers.html#ff13--nr13-channel-1-wavelength-low-write-only
+[linkNR14]: ./Audio_Registers.html#ff14--nr14-channel-1-wavelength-high--control
+[linkNR21]: ./Audio_Registers.html#sound-channel-2--pulse
+[linkNR22]: ./Audio_Registers.html#sound-channel-2--pulse
+[linkNR23]: ./Audio_Registers.html#sound-channel-2--pulse
+[linkNR24]: ./Audio_Registers.html#sound-channel-2--pulse
+[linkNR30]: ./Audio_Registers.html#ff1a--nr30-channel-3-dac-enable
+[linkNR31]: ./Audio_Registers.html#ff1b--nr31-channel-3-length-timer-write-only
+[linkNR32]: ./Audio_Registers.html#ff1c--nr32-channel-3-output-level
+[linkNR33]: ./Audio_Registers.html#ff1d--nr33-channel-3-wavelength-low-write-only
+[linkNR34]: ./Audio_Registers.html#ff1e--nr34-channel-3-wavelength-high--control
+[linkNR41]: ./Audio_Registers.html#ff20--nr41-channel-4-length-timer-write-only
+[linkNR42]: ./Audio_Registers.html#ff21--nr42-channel-4-volume--envelope
+[linkNR43]: ./Audio_Registers.html#ff22--nr43-channel-4-frequency--randomness
+[linkNR44]: ./Audio_Registers.html#ff23--nr44-channel-4-control
+[linkNR50]: ./Audio_Registers.html#ff24--nr50-master-volume--vin-panning
+[linkNR51]: ./Audio_Registers.html#ff25--nr51-sound-panning
+[linkNR52]: ./Audio_Registers.html#ff26--nr52-sound-onoff
+[linkWave pattern RAM]: ./Audio_Registers.html#ff30ff3f--wave-pattern-ram
+[linkLCDC]: ./LCDC.html#ff40--lcdc-lcd-control
+[linkSTAT]: ./STAT.html#ff41--stat-lcd-status
+[linkSCY]: ./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position
+[linkSCX]: ./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position
+[linkLY]: ./Scrolling.html#ff44--ly-lcd-y-coordinate-read-only
+[linkLYC]: ./Scrolling.html#ff45--lyc-ly-compare
+[linkDMA]: ./OAM_DMA_Transfer.html#ff46--dma-oam-dma-source-address--start
+[linkBGP (Non-CGB Mode only)]: ./Palettes.html#ff47--bgp-non-cgb-mode-only-bg-palette-data
+[linkOBP0 (Non-CGB Mode only)]: ./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data
+[linkOBP1 (Non-CGB Mode only)]: ./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data
+[linkWY]: ./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7
+[linkWX]: ./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7
+[linkKEY1 (CGB Mode only)]: ./CGB_Registers.html#ff4d--key1-cgb-mode-only-prepare-speed-switch
+[linkVBK (CGB Mode only)]: ./CGB_Registers.html#ff4f--vbk-cgb-mode-only-vram-bank
+[linkHDMA1 (CGB Mode only)]: ./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only
+[linkHDMA2 (CGB Mode only)]: ./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only
+[linkHDMA3 (CGB Mode only)]: ./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only
+[linkHDMA4 (CGB Mode only)]: ./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only
+[linkHDMA5 (CGB Mode only)]: ./CGB_Registers.html#ff55--hdma5-cgb-mode-only-vram-dma-lengthmodestart
+[linkRP (CGB Mode only)]: ./CGB_Registers.html#ff56--rp-cgb-mode-only-infrared-communications-port
+[linkBCPS/BGPI (CGB Mode only)]: ./Palettes.html#ff68--bcpsbgpi-cgb-mode-only-background-color-palette-specification--background-palette-index
+[linkBCPD/BGPD (CGB Mode only)]: ./Palettes.html#ff69--bcpdbgpd-cgb-mode-only-background-color-palette-data--background-palette-data
+[linkOCPS/OBPI (CGB Mode only)]: ./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data
+[linkOCPD/OBPD (CGB Mode only)]: ./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data
+[linkOPRI (CGB Mode only)]: ./CGB_Registers.html#ff6c--opri-cgb-mode-only-object-priority-mode
+[linkSVBK (CGB Mode only)]: ./CGB_Registers.html#ff70--svbk-cgb-mode-only-wram-bank
+[linkPCM12 (CGB Mode only)]: ./Audio_details.html#ff76--pcm12-cgb-mode-only-digital-outputs-1--2-read-only
+[linkPCM34 (CGB Mode only)]: ./Audio_details.html#ff77--pcm34-cgb-mode-only-digital-outputs-3--4-read-only
+[linkIE]: ./Interrupts.html#ffff--ie-interrupt-enable

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -32,7 +32,7 @@ $FF23      | [NR44]             | Sound channel 4 control                       
 $FF24      | [NR50]             | Master volume & VIN panning                                       | R/W                 | All
 $FF25      | [NR51]             | Sound panning                                                     | R/W                 | All
 $FF26      | [NR52]             | Sound on/off                                                      | Mixed               | All
-$FF30-FF3F | [Wave pattern ram] | Wave pattern RAM                                                  | R/W                 | All
+$FF30-FF3F | [Wave RAM] | Storage for one of the sound channels' waveform | R/W                 | All
 $FF40      | [LCDC]             | LCD control                                                       | R/W                 | All
 $FF41      | [STAT]             | LCD status                                                        | Mixed               | All
 $FF42      | [SCY]              | Viewport Y position                                               | R/W                 | All

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -1,67 +1,67 @@
 
 # Hardware Registers
 
-Address    | Name                        | Description                                                       | Readable / Writable
-:----------|-----------------------------|-------------------------------------------------------------------|----
-$FF00      | [P1/JOYP]                   | Joypad                                                            | R/W
-$FF01      | [SB]                        | Serial transfer data                                              | R/W
-$FF02      | [SC]                        | Serial transfer control                                           | R/W
-$FF04      | [DIV]                       | Divider register                                                  | R/W
-$FF05      | [TIMA]                      | Timer counter                                                     | R/W
-$FF06      | [TMA]                       | Timer modulo                                                      | R/W
-$FF07      | [TAC]                       | Timer control                                                     | R/W
-$FF0F      | [IF]                        | Interrupt flag                                                    | R/W
-$FF10      | [NR10]                      | Channel 1 sweep                                                   | R/W
-$FF11      | [NR11]                      | Channel 1 length timer & duty cycle                               | R/W
-$FF12      | [NR12]                      | Channel 1 volume & envelope                                       | R/W
-$FF13      | [NR13]                      | Channel 1 wavelength low                                          | W  
-$FF14      | [NR14]                      | Channel 1 wavelength high & control                               | R/W
-$FF16      | [NR21]                      | Channel 2 length timer & duty cycle                               | R/W
-$FF17      | [NR22]                      | Channel 2 volume & envelope                                       | R/W
-$FF18      | [NR23]                      | Channel 2 wavelength low                                          | W  
-$FF19      | [NR24]                      | Channel 2 wavelength high & control                               | R/W
-$FF1A      | [NR30]                      | Channel 3 DAC enable                                              | R/W
-$FF1B      | [NR31]                      | Channel 3 length timer                                            | W  
-$FF1C      | [NR32]                      | Channel 3 output level                                            | R/W
-$FF1D      | [NR33]                      | Channel 3 wavelength low                                          | W  
-$FF1E      | [NR34]                      | Channel 3 wavelength high & control                               | R/W
-$FF20      | [NR41]                      | Channel 4 length timer                                            | W  
-$FF21      | [NR42]                      | Channel 4 volume & envelope                                       | R/W
-$FF22      | [NR43]                      | Channel 4 frequency & randomness                                  | R/W
-$FF23      | [NR44]                      | Channel 4 control                                                 | R/W
-$FF24      | [NR50]                      | Master volume & VIN panning                                       | R/W
-$FF25      | [NR51]                      | Sound panning                                                     | R/W
-$FF26      | [NR52]                      | Sound on/off                                                      | R/W
-$FF30-FF3F | [Wave pattern ram]          | Wave pattern RAM                                                  | R/W
-$FF40      | [LCDC]                      | LCD control                                                       | R/W
-$FF41      | [STAT]                      | LCD status                                                        | R/W
-$FF42      | [SCY]                       | Viewport Y position                                               | R/W
-$FF43      | [SCX]                       | Viewport X position                                               | R/W
-$FF44      | [LY]                        | LCD Y coordinate                                                  | R  
-$FF45      | [LYC]                       | LY compare                                                        | R/W
-$FF46      | [DMA]                       | OAM DMA source address & start                                    | R/W
-$FF47      | [BGP (Non-CGB Mode only)]   | BG palette data                                                   | R/W
-$FF48      | [OBP0 (Non-CGB Mode only)]  | OBJ palette 0 data                                                | R/W
-$FF49      | [OBP1 (Non-CGB Mode only)]  | OBJ palette 1 data                                                | R/W
-$FF4A      | [WY]                        | Window Y position                                                 | R/W
-$FF4B      | [WX]                        | Window X position plus 7                                          | R/W
-$FF4D      | [KEY1 (CGB Mode only)]      | Prepare speed switch                                              | R/W
-$FF4F      | [VBK (CGB Mode only)]       | VRAM bank                                                         | R/W
-$FF51      | [HDMA1 (CGB Mode only)]     | VRAM DMA source high                                              | W  
-$FF52      | [HDMA2 (CGB Mode only)]     | VRAM DMA source low                                               | W  
-$FF53      | [HDMA3 (CGB Mode only)]     | VRAM DMA destination high                                         | W  
-$FF54      | [HDMA4 (CGB Mode only)]     | VRAM DMA destination low                                          | W  
-$FF55      | [HDMA5 (CGB Mode only)]     | VRAM DMA length/mode/start                                        | R/W
-$FF56      | [RP (CGB Mode only)]        | Infrared communications port                                      | R/W
-$FF68      | [BCPS/BGPI (CGB Mode only)] | Background color palette specification / Background palette index | R/W
-$FF69      | [BCPD/BGPD (CGB Mode only)] | Background color palette data / Background palette data           | R/W
-$FF6A      | [OCPS/OBPI (CGB Mode only)] | OBJ color palette specification / OBJ palette index               | R/W
-$FF6B      | [OCPD/OBPD (CGB Mode only)] | OBJ color palette data / OBJ palette data                         | R/W
-$FF6C      | [OPRI (CGB Mode only)]      | Object priority mode                                              | R/W
-$FF70      | [SVBK (CGB Mode only)]      | WRAM bank                                                         | R/W
-$FF76      | [PCM12 (CGB Mode only)]     | Digital outputs 1 & 2                                             | R  
-$FF77      | [PCM34 (CGB Mode only)]     | Digital outputs 3 & 4                                             | R  
-$FFFF      | [IE]                        | Interrupt enable                                                  | R/W
+Address    | Name               | Description                                                       | Readable / Writable | Models
+:----------|--------------------|-------------------------------------------------------------------|---------------------|-------
+$FF00      | [P1/JOYP]          | Joypad                                                            | Mixed               | All
+$FF01      | [SB]               | Serial transfer data                                              | R/W                 | All
+$FF02      | [SC]               | Serial transfer control                                           | R/W                 | Mixed
+$FF04      | [DIV]              | Divider register                                                  | R/W                 | All
+$FF05      | [TIMA]             | Timer counter                                                     | R/W                 | All
+$FF06      | [TMA]              | Timer modulo                                                      | R/W                 | All
+$FF07      | [TAC]              | Timer control                                                     | R/W                 | All
+$FF0F      | [IF]               | Interrupt flag                                                    | R/W                 | All
+$FF10      | [NR10]             | Channel 1 sweep                                                   | R/W                 | All
+$FF11      | [NR11]             | Channel 1 length timer & duty cycle                               | Mixed               | All
+$FF12      | [NR12]             | Channel 1 volume & envelope                                       | R/W                 | All
+$FF13      | [NR13]             | Channel 1 wavelength low                                          | W                   | All
+$FF14      | [NR14]             | Channel 1 wavelength high & control                               | Mixed               | All
+$FF16      | [NR21]             | Channel 2 length timer & duty cycle                               | Mixed               | All
+$FF17      | [NR22]             | Channel 2 volume & envelope                                       | R/W                 | All
+$FF18      | [NR23]             | Channel 2 wavelength low                                          | W                   | All
+$FF19      | [NR24]             | Channel 2 wavelength high & control                               | Mixed               | All
+$FF1A      | [NR30]             | Channel 3 DAC enable                                              | R/W                 | All
+$FF1B      | [NR31]             | Channel 3 length timer                                            | W                   | All
+$FF1C      | [NR32]             | Channel 3 output level                                            | R/W                 | All
+$FF1D      | [NR33]             | Channel 3 wavelength low                                          | W                   | All
+$FF1E      | [NR34]             | Channel 3 wavelength high & control                               | Mixed               | All
+$FF20      | [NR41]             | Channel 4 length timer                                            | W                   | All
+$FF21      | [NR42]             | Channel 4 volume & envelope                                       | R/W                 | All
+$FF22      | [NR43]             | Channel 4 frequency & randomness                                  | R/W                 | All
+$FF23      | [NR44]             | Channel 4 control                                                 | Mixed               | All
+$FF24      | [NR50]             | Master volume & VIN panning                                       | R/W                 | All
+$FF25      | [NR51]             | Sound panning                                                     | R/W                 | All
+$FF26      | [NR52]             | Sound on/off                                                      | Mixed               | All
+$FF30-FF3F | [Wave pattern ram] | Wave pattern RAM                                                  | R/W                 | All
+$FF40      | [LCDC]             | LCD control                                                       | R/W                 | All
+$FF41      | [STAT]             | LCD status                                                        | Mixed               | All
+$FF42      | [SCY]              | Viewport Y position                                               | R/W                 | All
+$FF43      | [SCX]              | Viewport X position                                               | R/W                 | All
+$FF44      | [LY]               | LCD Y coordinate                                                  | R                   | All
+$FF45      | [LYC]              | LY compare                                                        | R/W                 | All
+$FF46      | [DMA]              | OAM DMA source address & start                                    | R/W                 | All
+$FF47      | [BGP]              | BG palette data                                                   | R/W                 | DMG
+$FF48      | [OBP0]             | OBJ palette 0 data                                                | R/W                 | DMG
+$FF49      | [OBP1]             | OBJ palette 1 data                                                | R/W                 | DMG
+$FF4A      | [WY]               | Window Y position                                                 | R/W                 | All
+$FF4B      | [WX]               | Window X position plus 7                                          | R/W                 | All
+$FF4D      | [KEY1]             | Prepare speed switch                                              | Mixed               | CGB
+$FF4F      | [VBK]              | VRAM bank                                                         | R/W                 | CGB
+$FF51      | [HDMA1]            | VRAM DMA source high                                              | W                   | CGB
+$FF52      | [HDMA2]            | VRAM DMA source low                                               | W                   | CGB
+$FF53      | [HDMA3]            | VRAM DMA destination high                                         | W                   | CGB
+$FF54      | [HDMA4]            | VRAM DMA destination low                                          | W                   | CGB
+$FF55      | [HDMA5]            | VRAM DMA length/mode/start                                        | R/W                 | CGB
+$FF56      | [RP]               | Infrared communications port                                      | Mixed               | CGB
+$FF68      | [BCPS/BGPI]        | Background color palette specification / Background palette index | R/W                 | CGB
+$FF69      | [BCPD/BGPD]        | Background color palette data / Background palette data           | R/W                 | CGB
+$FF6A      | [OCPS/OBPI]        | OBJ color palette specification / OBJ palette index               | R/W                 | CGB
+$FF6B      | [OCPD/OBPD]        | OBJ color palette data / OBJ palette data                         | R/W                 | CGB
+$FF6C      | [OPRI]             | Object priority mode                                              | R/W                 | CGB
+$FF70      | [SVBK]             | WRAM bank                                                         | R/W                 | CGB
+$FF76      | [PCM12]            | Digital outputs 1 & 2                                             | R                   | CGB
+$FF77      | [PCM34]            | Digital outputs 3 & 4                                             | R                   | CGB
+$FFFF      | [IE]               | Interrupt enable                                                  | R/W                 | All
 
 [P1/JOYP]: <#FF00 — P1/JOYP: Joypad>
 [SB]: <#FF01 — SB: Serial transfer data>
@@ -100,25 +100,25 @@ $FFFF      | [IE]                        | Interrupt enable                     
 [LY]: <#FF44 — LY: LCD Y coordinate \[read-only\]>
 [LYC]: <#FF45 — LYC: LY compare>
 [DMA]: <#FF46 — DMA: OAM DMA source address & start>
-[BGP (Non-CGB Mode only)]: <#FF47 — BGP (Non-CGB Mode only): BG palette data>
-[OBP0 (Non-CGB Mode only)]: <#FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data>
-[OBP1 (Non-CGB Mode only)]: <#FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data>
+[BGP]: <#FF47 — BGP (Non-CGB Mode only): BG palette data>
+[OBP0]: <#FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data>
+[OBP1]: <#FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data>
 [WY]: <#FF4A–FF4B — WY, WX: Window Y position, X position plus 7>
 [WX]: <#FF4A–FF4B — WY, WX: Window Y position, X position plus 7>
-[KEY1 (CGB Mode only)]: <#FF4D — KEY1 (CGB Mode only): Prepare speed switch>
-[VBK (CGB Mode only)]: <#FF4F — VBK (CGB Mode only): VRAM bank>
-[HDMA1 (CGB Mode only)]: <#FF51–FF52 — HDMA1, HDMA2 (CGB Mode only): VRAM DMA source (high, low) \[write-only\]>
-[HDMA2 (CGB Mode only)]: <#FF51–FF52 — HDMA1, HDMA2 (CGB Mode only): VRAM DMA source (high, low) \[write-only\]>
-[HDMA3 (CGB Mode only)]: <#FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]>
-[HDMA4 (CGB Mode only)]: <#FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]>
-[HDMA5 (CGB Mode only)]: <#FF55 — HDMA5 (CGB Mode only): VRAM DMA length/mode/start>
-[RP (CGB Mode only)]: <#FF56 — RP (CGB Mode only): Infrared communications port>
-[BCPS/BGPI (CGB Mode only)]: <#FF68 — BCPS/BGPI (CGB Mode only): Background color palette specification / Background palette index>
-[BCPD/BGPD (CGB Mode only)]: <#FF69 — BCPD/BGPD (CGB Mode only): Background color palette data / Background palette data>
-[OCPS/OBPI (CGB Mode only)]: <#FF6A–FF6B — OCPS/OBPI, OCPD/OBPD (CGB Mode only): OBJ color palette specification / OBJ palette index, OBJ color palette data / OBJ palette data>
-[OCPD/OBPD (CGB Mode only)]: <#FF6A–FF6B — OCPS/OBPI, OCPD/OBPD (CGB Mode only): OBJ color palette specification / OBJ palette index, OBJ color palette data / OBJ palette data>
-[OPRI (CGB Mode only)]: <#FF6C — OPRI (CGB Mode only): Object priority mode>
-[SVBK (CGB Mode only)]: <#FF70 — SVBK (CGB Mode only): WRAM bank>
-[PCM12 (CGB Mode only)]: <#FF76 — PCM12 (CGB Mode only): Digital outputs 1 & 2 \[read-only\]>
-[PCM34 (CGB Mode only)]: <#FF77 — PCM34 (CGB Mode only): Digital outputs 3 & 4 \[read-only\]>
+[KEY1]: <#FF4D — KEY1 (CGB Mode only): Prepare speed switch>
+[VBK]: <#FF4F — VBK (CGB Mode only): VRAM bank>
+[HDMA1]: <#FF51–FF52 — HDMA1, HDMA2 (CGB Mode only): VRAM DMA source (high, low) \[write-only\]>
+[HDMA2]: <#FF51–FF52 — HDMA1, HDMA2 (CGB Mode only): VRAM DMA source (high, low) \[write-only\]>
+[HDMA3]: <#FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]>
+[HDMA4]: <#FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]>
+[HDMA5]: <#FF55 — HDMA5 (CGB Mode only): VRAM DMA length/mode/start>
+[RP]: <#FF56 — RP (CGB Mode only): Infrared communications port>
+[BCPS/BGPI]: <#FF68 — BCPS/BGPI (CGB Mode only): Background color palette specification / Background palette index>
+[BCPD/BGPD]: <#FF69 — BCPD/BGPD (CGB Mode only): Background color palette data / Background palette data>
+[OCPS/OBPI]: <#FF6A–FF6B — OCPS/OBPI, OCPD/OBPD (CGB Mode only): OBJ color palette specification / OBJ palette index, OBJ color palette data / OBJ palette data>
+[OCPD/OBPD]: <#FF6A–FF6B — OCPS/OBPI, OCPD/OBPD (CGB Mode only): OBJ color palette specification / OBJ palette index, OBJ color palette data / OBJ palette data>
+[OPRI]: <#FF6C — OPRI (CGB Mode only): Object priority mode>
+[SVBK]: <#FF70 — SVBK (CGB Mode only): WRAM bank>
+[PCM12]: <#FF76 — PCM12 (CGB Mode only): Digital outputs 1 & 2 \[read-only\]>
+[PCM34]: <#FF77 — PCM34 (CGB Mode only): Digital outputs 3 & 4 \[read-only\]>
 [IE]: <#FFFF — IE: Interrupt enable>

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -1,67 +1,67 @@
 
 # Hardware Registers
 
-Address    | Name               | Description                                                       | Readable / Writable | Models
------------|--------------------|-------------------------------------------------------------------|---------------------|-------
-$FF00      | [P1/JOYP]          | Joypad                                                            | Mixed               | All
-$FF01      | [SB]               | Serial transfer data                                              | R/W                 | All
-$FF02      | [SC]               | Serial transfer control                                           | R/W                 | Mixed
-$FF04      | [DIV]              | Divider register                                                  | R/W                 | All
-$FF05      | [TIMA]             | Timer counter                                                     | R/W                 | All
-$FF06      | [TMA]              | Timer modulo                                                      | R/W                 | All
-$FF07      | [TAC]              | Timer control                                                     | R/W                 | All
-$FF0F      | [IF]               | Interrupt flag                                                    | R/W                 | All
-$FF10      | [NR10]             | Sound channel 1 sweep                                            | R/W                 | All
-$FF11      | [NR11]             | Sound channel 1 length timer & duty cycle                        | Mixed               | All
-$FF12      | [NR12]             | Sound channel 1 volume & envelope                                | R/W                 | All
-$FF13      | [NR13]             | Sound channel 1 wavelength low                                   | W                   | All
-$FF14      | [NR14]             | Sound channel 1 wavelength high & control                        | Mixed               | All
-$FF16      | [NR21]             | Sound channel 2 length timer & duty cycle                        | Mixed               | All
-$FF17      | [NR22]             | Sound channel 2 volume & envelope                                | R/W                 | All
-$FF18      | [NR23]             | Sound channel 2 wavelength low                                   | W                   | All
-$FF19      | [NR24]             | Sound channel 2 wavelength high & control                        | Mixed               | All
-$FF1A      | [NR30]             | Sound channel 3 DAC enable                                       | R/W                 | All
-$FF1B      | [NR31]             | Sound channel 3 length timer                                     | W                   | All
-$FF1C      | [NR32]             | Sound channel 3 output level                                     | R/W                 | All
-$FF1D      | [NR33]             | Sound channel 3 wavelength low                                   | W                   | All
-$FF1E      | [NR34]             | Sound channel 3 wavelength high & control                        | Mixed               | All
-$FF20      | [NR41]             | Sound channel 4 length timer                                     | W                   | All
-$FF21      | [NR42]             | Sound channel 4 volume & envelope                                | R/W                 | All
-$FF22      | [NR43]             | Sound channel 4 frequency & randomness                           | R/W                 | All
-$FF23      | [NR44]             | Sound channel 4 control                                          | Mixed               | All
-$FF24      | [NR50]             | Master volume & VIN panning                                       | R/W                 | All
-$FF25      | [NR51]             | Sound panning                                                     | R/W                 | All
-$FF26      | [NR52]             | Sound on/off                                                      | Mixed               | All
-$FF30-FF3F | [Wave RAM] | Storage for one of the sound channels' waveform | R/W                 | All
-$FF40      | [LCDC]             | LCD control                                                       | R/W                 | All
-$FF41      | [STAT]             | LCD status                                                        | Mixed               | All
-$FF42      | [SCY]              | Viewport Y position                                               | R/W                 | All
-$FF43      | [SCX]              | Viewport X position                                               | R/W                 | All
-$FF44      | [LY]               | LCD Y coordinate                                                  | R                   | All
-$FF45      | [LYC]              | LY compare                                                        | R/W                 | All
-$FF46      | [DMA]              | OAM DMA source address & start                                    | R/W                 | All
-$FF47      | [BGP]              | BG palette data                                                   | R/W                 | DMG
-$FF48      | [OBP0]             | OBJ palette 0 data                                                | R/W                 | DMG
-$FF49      | [OBP1]             | OBJ palette 1 data                                                | R/W                 | DMG
-$FF4A      | [WY]               | Window Y position                                                 | R/W                 | All
-$FF4B      | [WX]               | Window X position plus 7                                          | R/W                 | All
-$FF4D      | [KEY1]             | Prepare speed switch                                              | Mixed               | CGB
-$FF4F      | [VBK]              | VRAM bank                                                         | R/W                 | CGB
-$FF51      | [HDMA1]            | VRAM DMA source high                                              | W                   | CGB
-$FF52      | [HDMA2]            | VRAM DMA source low                                               | W                   | CGB
-$FF53      | [HDMA3]            | VRAM DMA destination high                                         | W                   | CGB
-$FF54      | [HDMA4]            | VRAM DMA destination low                                          | W                   | CGB
-$FF55      | [HDMA5]            | VRAM DMA length/mode/start                                        | R/W                 | CGB
-$FF56      | [RP]               | Infrared communications port                                      | Mixed               | CGB
-$FF68      | [BCPS/BGPI]        | Background color palette specification / Background palette index | R/W                 | CGB
-$FF69      | [BCPD/BGPD]        | Background color palette data / Background palette data           | R/W                 | CGB
-$FF6A      | [OCPS/OBPI]        | OBJ color palette specification / OBJ palette index               | R/W                 | CGB
-$FF6B      | [OCPD/OBPD]        | OBJ color palette data / OBJ palette data                         | R/W                 | CGB
-$FF6C      | [OPRI]             | Object priority mode                                              | R/W                 | CGB
-$FF70      | [SVBK]             | WRAM bank                                                         | R/W                 | CGB
-$FF76      | [PCM12]            | Audio digital outputs 1 & 2                                       | R                   | CGB
-$FF77      | [PCM34]            | Audio digital outputs 3 & 4                                       | R                   | CGB
-$FFFF      | [IE]               | Interrupt enable                                                  | R/W                 | All
+Address    | Name        | Description                                                       | Readable / Writable | Models
+-----------|-------------|-------------------------------------------------------------------|---------------------|-------
+$FF00      | [P1/JOYP]   | Joypad                                                            | Mixed               | All
+$FF01      | [SB]        | Serial transfer data                                              | R/W                 | All
+$FF02      | [SC]        | Serial transfer control                                           | R/W                 | Mixed
+$FF04      | [DIV]       | Divider register                                                  | R/W                 | All
+$FF05      | [TIMA]      | Timer counter                                                     | R/W                 | All
+$FF06      | [TMA]       | Timer modulo                                                      | R/W                 | All
+$FF07      | [TAC]       | Timer control                                                     | R/W                 | All
+$FF0F      | [IF]        | Interrupt flag                                                    | R/W                 | All
+$FF10      | [NR10]      | Sound channel 1 sweep                                             | R/W                 | All
+$FF11      | [NR11]      | Sound channel 1 length timer & duty cycle                         | Mixed               | All
+$FF12      | [NR12]      | Sound channel 1 volume & envelope                                 | R/W                 | All
+$FF13      | [NR13]      | Sound channel 1 wavelength low                                    | W                   | All
+$FF14      | [NR14]      | Sound channel 1 wavelength high & control                         | Mixed               | All
+$FF16      | [NR21]      | Sound channel 2 length timer & duty cycle                         | Mixed               | All
+$FF17      | [NR22]      | Sound channel 2 volume & envelope                                 | R/W                 | All
+$FF18      | [NR23]      | Sound channel 2 wavelength low                                    | W                   | All
+$FF19      | [NR24]      | Sound channel 2 wavelength high & control                         | Mixed               | All
+$FF1A      | [NR30]      | Sound channel 3 DAC enable                                        | R/W                 | All
+$FF1B      | [NR31]      | Sound channel 3 length timer                                      | W                   | All
+$FF1C      | [NR32]      | Sound channel 3 output level                                      | R/W                 | All
+$FF1D      | [NR33]      | Sound channel 3 wavelength low                                    | W                   | All
+$FF1E      | [NR34]      | Sound channel 3 wavelength high & control                         | Mixed               | All
+$FF20      | [NR41]      | Sound channel 4 length timer                                      | W                   | All
+$FF21      | [NR42]      | Sound channel 4 volume & envelope                                 | R/W                 | All
+$FF22      | [NR43]      | Sound channel 4 frequency & randomness                            | R/W                 | All
+$FF23      | [NR44]      | Sound channel 4 control                                           | Mixed               | All
+$FF24      | [NR50]      | Master volume & VIN panning                                       | R/W                 | All
+$FF25      | [NR51]      | Sound panning                                                     | R/W                 | All
+$FF26      | [NR52]      | Sound on/off                                                      | Mixed               | All
+$FF30-FF3F | [Wave RAM]  | Storage for one of the sound channels' waveform                   | R/W                 | All
+$FF40      | [LCDC]      | LCD control                                                       | R/W                 | All
+$FF41      | [STAT]      | LCD status                                                        | Mixed               | All
+$FF42      | [SCY]       | Viewport Y position                                               | R/W                 | All
+$FF43      | [SCX]       | Viewport X position                                               | R/W                 | All
+$FF44      | [LY]        | LCD Y coordinate                                                  | R                   | All
+$FF45      | [LYC]       | LY compare                                                        | R/W                 | All
+$FF46      | [DMA]       | OAM DMA source address & start                                    | R/W                 | All
+$FF47      | [BGP]       | BG palette data                                                   | R/W                 | DMG
+$FF48      | [OBP0]      | OBJ palette 0 data                                                | R/W                 | DMG
+$FF49      | [OBP1]      | OBJ palette 1 data                                                | R/W                 | DMG
+$FF4A      | [WY]        | Window Y position                                                 | R/W                 | All
+$FF4B      | [WX]        | Window X position plus 7                                          | R/W                 | All
+$FF4D      | [KEY1]      | Prepare speed switch                                              | Mixed               | CGB
+$FF4F      | [VBK]       | VRAM bank                                                         | R/W                 | CGB
+$FF51      | [HDMA1]     | VRAM DMA source high                                              | W                   | CGB
+$FF52      | [HDMA2]     | VRAM DMA source low                                               | W                   | CGB
+$FF53      | [HDMA3]     | VRAM DMA destination high                                         | W                   | CGB
+$FF54      | [HDMA4]     | VRAM DMA destination low                                          | W                   | CGB
+$FF55      | [HDMA5]     | VRAM DMA length/mode/start                                        | R/W                 | CGB
+$FF56      | [RP]        | Infrared communications port                                      | Mixed               | CGB
+$FF68      | [BCPS/BGPI] | Background color palette specification / Background palette index | R/W                 | CGB
+$FF69      | [BCPD/BGPD] | Background color palette data / Background palette data           | R/W                 | CGB
+$FF6A      | [OCPS/OBPI] | OBJ color palette specification / OBJ palette index               | R/W                 | CGB
+$FF6B      | [OCPD/OBPD] | OBJ color palette data / OBJ palette data                         | R/W                 | CGB
+$FF6C      | [OPRI]      | Object priority mode                                              | R/W                 | CGB
+$FF70      | [SVBK]      | WRAM bank                                                         | R/W                 | CGB
+$FF76      | [PCM12]     | Audio digital outputs 1 & 2                                       | R                   | CGB
+$FF77      | [PCM34]     | Audio digital outputs 3 & 4                                       | R                   | CGB
+$FFFF      | [IE]        | Interrupt enable                                                  | R/W                 | All
 
 [P1/JOYP]: <#FF00 — P1/JOYP: Joypad>
 [SB]: <#FF01 — SB: Serial transfer data>
@@ -92,7 +92,7 @@ $FFFF      | [IE]               | Interrupt enable                              
 [NR50]: <#FF24 — NR50: Master volume & VIN panning>
 [NR51]: <#FF25 — NR51: Sound panning>
 [NR52]: <#FF26 — NR52: Sound on/off>
-[Wave pattern RAM]: <#FF30–FF3F — Wave pattern RAM>
+[Wave RAM]: <#FF30–FF3F — Wave pattern RAM>
 [LCDC]: <#FF40 — LCDC: LCD control>
 [STAT]: <#FF41 — STAT: LCD status>
 [SCY]: <#FF42–FF43 — SCY, SCX: Viewport Y position, X position>

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -3,6 +3,7 @@
 
 | Addr       | Name                                                       | Description                                                       | R/W |
 |:-----------|------------------------------------------------------------|-------------------------------------------------------------------|-----|
+| $FF00      | [P1/JOYP][linkP1/JOYP]                                     | Joypad                                                            | R/W |
 | $FF01      | [SB][linkSB]                                               | Serial transfer data                                              | R/W |
 | $FF02      | [SC][linkSC]                                               | Serial transfer control                                           | R/W |
 | $FF04      | [DIV][linkDIV]                                             | Divider register                                                  | R/W |

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -1,0 +1,369 @@
+
+# Hardware Registers
+
+<table>
+  <thead>
+    <tr>
+      <th>Addr</th>
+      <th>Name</th>
+      <th>Description</th>
+      <th>R/W</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>$FF00</td>
+      <td><a href="./Joypad_Input.html#ff00--p1joyp-joypad">P1/JOYP</a></td>
+      <td>Joypad</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF01</td>
+      <td><a href="./Serial_Data_Transfer_(Link_Cable).html#ff01--sb-serial-transfer-data">SB</a></td>
+      <td>Serial transfer data</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF02</td>
+      <td><a href="./Serial_Data_Transfer_(Link_Cable).html#ff02--sc-serial-transfer-control">SC</a></td>
+      <td>Serial transfer control</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF04</td>
+      <td><a href="./Timer_and_Divider_Registers.html#ff04--div-divider-register">DIV</a></td>
+      <td>Divider register</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF05</td>
+      <td><a href="./Timer_and_Divider_Registers.html#ff05--tima-timer-counter">TIMA</a></td>
+      <td>Timer counter</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF06</td>
+      <td><a href="./Timer_and_Divider_Registers.html#ff06--tma-timer-modulo">TMA</a></td>
+      <td>Timer modulo</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF07</td>
+      <td><a href="./Timer_and_Divider_Registers.html#ff07--tac-timer-control">TAC</a></td>
+      <td>Timer control</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF0F</td>
+      <td><a href="./Interrupts.html#ff0f--if-interrupt-flag">IF</a></td>
+      <td>Interrupt flag</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF10</td>
+      <td><a href="./Audio_Registers.html#ff10--nr10-channel-1-sweep">NR10</a></td>
+      <td>Channel 1 sweep</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF11</td>
+      <td><a href="./Audio_Registers.html#ff11--nr11-channel-1-length-timer--duty-cycle">NR11</a></td>
+      <td>Channel 1 length timer & duty cycle</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF12</td>
+      <td><a href="./Audio_Registers.html#ff12--nr12-channel-1-volume--envelope">NR12</a></td>
+      <td>Channel 1 volume & envelope</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF13</td>
+      <td><a href="./Audio_Registers.html#ff13--nr13-channel-1-wavelength-low-write-only">NR13</a></td>
+      <td>Channel 1 wavelength low</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF14</td>
+      <td><a href="./Audio_Registers.html#ff14--nr14-channel-1-wavelength-high--control">NR14</a></td>
+      <td>Channel 1 wavelength high & control</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF16</td>
+      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR21</a></td>
+      <td>Channel 2 length timer & duty cycle</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF17</td>
+      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR22</a></td>
+      <td>Channel 2 volume & envelope</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF18</td>
+      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR23</a></td>
+      <td>Channel 2 wavelength low</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF19</td>
+      <td><a href="./Audio_Registers.html#sound-channel-2--pulse">NR24</a></td>
+      <td>Channel 2 wavelength high & control</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF1A</td>
+      <td><a href="./Audio_Registers.html#ff1a--nr30-channel-3-dac-enable">NR30</a></td>
+      <td>Channel 3 DAC enable</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF1B</td>
+      <td><a href="./Audio_Registers.html#ff1b--nr31-channel-3-length-timer-write-only">NR31</a></td>
+      <td>Channel 3 length timer</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF1C</td>
+      <td><a href="./Audio_Registers.html#ff1c--nr32-channel-3-output-level">NR32</a></td>
+      <td>Channel 3 output level</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF1D</td>
+      <td><a href="./Audio_Registers.html#ff1d--nr33-channel-3-wavelength-low-write-only">NR33</a></td>
+      <td>Channel 3 wavelength low</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF1E</td>
+      <td><a href="./Audio_Registers.html#ff1e--nr34-channel-3-wavelength-high--control">NR34</a></td>
+      <td>Channel 3 wavelength high & control</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF20</td>
+      <td><a href="./Audio_Registers.html#ff20--nr41-channel-4-length-timer-write-only">NR41</a></td>
+      <td>Channel 4 length timer</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF21</td>
+      <td><a href="./Audio_Registers.html#ff21--nr42-channel-4-volume--envelope">NR42</a></td>
+      <td>Channel 4 volume & envelope</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF22</td>
+      <td><a href="./Audio_Registers.html#ff22--nr43-channel-4-frequency--randomness">NR43</a></td>
+      <td>Channel 4 frequency & randomness</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF23</td>
+      <td><a href="./Audio_Registers.html#ff23--nr44-channel-4-control">NR44</a></td>
+      <td>Channel 4 control</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF24</td>
+      <td><a href="./Audio_Registers.html#ff24--nr50-master-volume--vin-panning">NR50</a></td>
+      <td>Master volume & VIN panning</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF25</td>
+      <td><a href="./Audio_Registers.html#ff25--nr51-sound-panning">NR51</a></td>
+      <td>Sound panning</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF26</td>
+      <td><a href="./Audio_Registers.html#ff26--nr52-sound-onoff">NR52</a></td>
+      <td>Sound on/off</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF30-FF3F</td>
+      <td><a href="./Audio_Registers.html#ff30ff3f--wave-pattern-ram"></a></td>
+      <td>Wave pattern RAM</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF40</td>
+      <td><a href="./LCDC.html#ff40--lcdc-lcd-control">LCDC</a></td>
+      <td>LCD control</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF41</td>
+      <td><a href="./STAT.html#ff41--stat-lcd-status">STAT</a></td>
+      <td>LCD status</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF42</td>
+      <td><a href="./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position">SCY</a></td>
+      <td>Viewport Y position</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF43</td>
+      <td><a href="./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position">SCX</a></td>
+      <td>Viewport X position</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF44</td>
+      <td><a href="./Scrolling.html#ff44--ly-lcd-y-coordinate-read-only">LY</a></td>
+      <td>LCD Y coordinate</td>
+      <td>R</td>
+    </tr>
+    <tr>
+      <td>$FF45</td>
+      <td><a href="./Scrolling.html#ff45--lyc-ly-compare">LYC</a></td>
+      <td>LY compare</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF46</td>
+      <td><a href="./OAM_DMA_Transfer.html#ff46--dma-oam-dma-source-address--start">DMA</a></td>
+      <td>OAM DMA source address & start</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF47</td>
+      <td><a href="./Palettes.html#ff47--bgp-non-cgb-mode-only-bg-palette-data">BGP (Non-CGB Mode only)</a></td>
+      <td>BG palette data</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF48</td>
+      <td><a href="./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data">OBP0 (Non-CGB Mode only)</a></td>
+      <td>OBJ palette 0 data</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF49</td>
+      <td><a href="./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data">OBP1 (Non-CGB Mode only)</a></td>
+      <td>OBJ palette 1 data</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF4A</td>
+      <td><a href="./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7">WY</a></td>
+      <td>Window Y position</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF4B</td>
+      <td><a href="./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7">WX</a></td>
+      <td>Window X position plus 7</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF4D</td>
+      <td><a href="./CGB_Registers.html#ff4d--key1-cgb-mode-only-prepare-speed-switch">KEY1 (CGB Mode only)</a></td>
+      <td>Prepare speed switch</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF4F</td>
+      <td><a href="./CGB_Registers.html#ff4f--vbk-cgb-mode-only-vram-bank">VBK (CGB Mode only)</a></td>
+      <td>VRAM bank</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF51</td>
+      <td><a href="./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only">HDMA1 (CGB Mode only)</a></td>
+      <td>VRAM DMA source high</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF52</td>
+      <td><a href="./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only">HDMA2 (CGB Mode only)</a></td>
+      <td>VRAM DMA source low</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF53</td>
+      <td><a href="./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only">HDMA3 (CGB Mode only)</a></td>
+      <td>VRAM DMA destination high</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF54</td>
+      <td><a href="./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only">HDMA4 (CGB Mode only)</a></td>
+      <td>VRAM DMA destination low</td>
+      <td>W</td>
+    </tr>
+    <tr>
+      <td>$FF55</td>
+      <td><a href="./CGB_Registers.html#ff55--hdma5-cgb-mode-only-vram-dma-lengthmodestart">HDMA5 (CGB Mode only)</a></td>
+      <td>VRAM DMA length/mode/start</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF56</td>
+      <td><a href="./CGB_Registers.html#ff56--rp-cgb-mode-only-infrared-communications-port">RP (CGB Mode only)</a></td>
+      <td>Infrared communications port</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF68</td>
+      <td><a href="./Palettes.html#ff68--bcpsbgpi-cgb-mode-only-background-color-palette-specification--background-palette-index">BCPS/BGPI (CGB Mode only)</a></td>
+      <td>Background color palette specification / Background palette index</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF69</td>
+      <td><a href="./Palettes.html#ff69--bcpdbgpd-cgb-mode-only-background-color-palette-data--background-palette-data">BCPD/BGPD (CGB Mode only)</a></td>
+      <td>Background color palette data / Background palette data</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF6A</td>
+      <td><a href="./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data">OCPS/OBPI (CGB Mode only)</a></td>
+      <td>OBJ color palette specification / OBJ palette index</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF6B</td>
+      <td><a href="./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data">OCPD/OBPD (CGB Mode only)</a></td>
+      <td>OBJ color palette data / OBJ palette data</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF6C</td>
+      <td><a href="./CGB_Registers.html#ff6c--opri-cgb-mode-only-object-priority-mode">OPRI (CGB Mode only)</a></td>
+      <td>Object priority mode</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF70</td>
+      <td><a href="./CGB_Registers.html#ff70--svbk-cgb-mode-only-wram-bank">SVBK (CGB Mode only)</a></td>
+      <td>WRAM bank</td>
+      <td>R/W</td>
+    </tr>
+    <tr>
+      <td>$FF76</td>
+      <td><a href="./Audio_details.html#ff76--pcm12-cgb-mode-only-digital-outputs-1--2-read-only">PCM12 (CGB Mode only)</a></td>
+      <td>Digital outputs 1 & 2</td>
+      <td>R</td>
+    </tr>
+    <tr>
+      <td>$FF77</td>
+      <td><a href="./Audio_details.html#ff77--pcm34-cgb-mode-only-digital-outputs-3--4-read-only">PCM34 (CGB Mode only)</a></td>
+      <td>Digital outputs 3 & 4</td>
+      <td>R</td>
+    </tr>
+    <tr>
+      <td>$FFFF</td>
+      <td><a href="./Interrupts.html#ffff--ie-interrupt-enable">IE</a></td>
+      <td>Interrupt enable</td>
+      <td>R/W</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -63,7 +63,7 @@
 | $FF77      | [PCM34 (CGB Mode only)][linkPCM34 (CGB Mode only)]         | Digital outputs 3 & 4                                             | R   |
 | $FFFF      | [IE][linkIE]                                               | Interrupt enable                                                  | R/W |
 
-
+[linkP1/JOYP]: ./Joypad_Input.html#ff00--p1joyp-joypad
 [linkSB]: ./Serial_Data_Transfer_(Link_Cable).html#ff01--sb-serial-transfer-data
 [linkSC]: ./Serial_Data_Transfer_(Link_Cable).html#ff02--sc-serial-transfer-control
 [linkDIV]: ./Timer_and_Divider_Registers.html#ff04--div-divider-register

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -59,8 +59,8 @@ $FF6A      | [OCPS/OBPI]        | OBJ color palette specification / OBJ palette 
 $FF6B      | [OCPD/OBPD]        | OBJ color palette data / OBJ palette data                         | R/W                 | CGB
 $FF6C      | [OPRI]             | Object priority mode                                              | R/W                 | CGB
 $FF70      | [SVBK]             | WRAM bank                                                         | R/W                 | CGB
-$FF76      | [PCM12]            | Digital outputs 1 & 2                                             | R                   | CGB
-$FF77      | [PCM34]            | Digital outputs 3 & 4                                             | R                   | CGB
+$FF76      | [PCM12]            | Audio digital outputs 1 & 2                                       | R                   | CGB
+$FF77      | [PCM34]            | Audio digital outputs 3 & 4                                       | R                   | CGB
 $FFFF      | [IE]               | Interrupt enable                                                  | R/W                 | All
 
 [P1/JOYP]: <#FF00 — P1/JOYP: Joypad>

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -2,7 +2,7 @@
 # Hardware Registers
 
 Address    | Name               | Description                                                       | Readable / Writable | Models
-:----------|--------------------|-------------------------------------------------------------------|---------------------|-------
+-----------|--------------------|-------------------------------------------------------------------|---------------------|-------
 $FF00      | [P1/JOYP]          | Joypad                                                            | Mixed               | All
 $FF01      | [SB]               | Serial transfer data                                              | R/W                 | All
 $FF02      | [SC]               | Serial transfer control                                           | R/W                 | Mixed

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -1,124 +1,124 @@
 
 # Hardware Registers
 
-| Addr       | Name                                                       | Description                                                       | R/W |
-|:-----------|------------------------------------------------------------|-------------------------------------------------------------------|-----|
-| $FF00      | [P1/JOYP][linkP1/JOYP]                                     | Joypad                                                            | R/W |
-| $FF01      | [SB][linkSB]                                               | Serial transfer data                                              | R/W |
-| $FF02      | [SC][linkSC]                                               | Serial transfer control                                           | R/W |
-| $FF04      | [DIV][linkDIV]                                             | Divider register                                                  | R/W |
-| $FF05      | [TIMA][linkTIMA]                                           | Timer counter                                                     | R/W |
-| $FF06      | [TMA][linkTMA]                                             | Timer modulo                                                      | R/W |
-| $FF07      | [TAC][linkTAC]                                             | Timer control                                                     | R/W |
-| $FF0F      | [IF][linkIF]                                               | Interrupt flag                                                    | R/W |
-| $FF10      | [NR10][linkNR10]                                           | Channel 1 sweep                                                   | R/W |
-| $FF11      | [NR11][linkNR11]                                           | Channel 1 length timer & duty cycle                               | R/W |
-| $FF12      | [NR12][linkNR12]                                           | Channel 1 volume & envelope                                       | R/W |
-| $FF13      | [NR13][linkNR13]                                           | Channel 1 wavelength low                                          | W   |
-| $FF14      | [NR14][linkNR14]                                           | Channel 1 wavelength high & control                               | R/W |
-| $FF16      | [NR21][linkNR21]                                           | Channel 2 length timer & duty cycle                               | R/W |
-| $FF17      | [NR22][linkNR22]                                           | Channel 2 volume & envelope                                       | R/W |
-| $FF18      | [NR23][linkNR23]                                           | Channel 2 wavelength low                                          | W   |
-| $FF19      | [NR24][linkNR24]                                           | Channel 2 wavelength high & control                               | R/W |
-| $FF1A      | [NR30][linkNR30]                                           | Channel 3 DAC enable                                              | R/W |
-| $FF1B      | [NR31][linkNR31]                                           | Channel 3 length timer                                            | W   |
-| $FF1C      | [NR32][linkNR32]                                           | Channel 3 output level                                            | R/W |
-| $FF1D      | [NR33][linkNR33]                                           | Channel 3 wavelength low                                          | W   |
-| $FF1E      | [NR34][linkNR34]                                           | Channel 3 wavelength high & control                               | R/W |
-| $FF20      | [NR41][linkNR41]                                           | Channel 4 length timer                                            | W   |
-| $FF21      | [NR42][linkNR42]                                           | Channel 4 volume & envelope                                       | R/W |
-| $FF22      | [NR43][linkNR43]                                           | Channel 4 frequency & randomness                                  | R/W |
-| $FF23      | [NR44][linkNR44]                                           | Channel 4 control                                                 | R/W |
-| $FF24      | [NR50][linkNR50]                                           | Master volume & VIN panning                                       | R/W |
-| $FF25      | [NR51][linkNR51]                                           | Sound panning                                                     | R/W |
-| $FF26      | [NR52][linkNR52]                                           | Sound on/off                                                      | R/W |
-| $FF30-FF3F | [Wave pattern ram][linkWave pattern ram]                   | Wave pattern RAM                                                  | R/W |
-| $FF40      | [LCDC][linkLCDC]                                           | LCD control                                                       | R/W |
-| $FF41      | [STAT][linkSTAT]                                           | LCD status                                                        | R/W |
-| $FF42      | [SCY][linkSCY]                                             | Viewport Y position                                               | R/W |
-| $FF43      | [SCX][linkSCX]                                             | Viewport X position                                               | R/W |
-| $FF44      | [LY][linkLY]                                               | LCD Y coordinate                                                  | R   |
-| $FF45      | [LYC][linkLYC]                                             | LY compare                                                        | R/W |
-| $FF46      | [DMA][linkDMA]                                             | OAM DMA source address & start                                    | R/W |
-| $FF47      | [BGP (Non-CGB Mode only)][linkBGP (Non-CGB Mode only)]     | BG palette data                                                   | R/W |
-| $FF48      | [OBP0 (Non-CGB Mode only)][linkOBP0 (Non-CGB Mode only)]   | OBJ palette 0 data                                                | R/W |
-| $FF49      | [OBP1 (Non-CGB Mode only)][linkOBP1 (Non-CGB Mode only)]   | OBJ palette 1 data                                                | R/W |
-| $FF4A      | [WY][linkWY]                                               | Window Y position                                                 | R/W |
-| $FF4B      | [WX][linkWX]                                               | Window X position plus 7                                          | R/W |
-| $FF4D      | [KEY1 (CGB Mode only)][linkKEY1 (CGB Mode only)]           | Prepare speed switch                                              | R/W |
-| $FF4F      | [VBK (CGB Mode only)][linkVBK (CGB Mode only)]             | VRAM bank                                                         | R/W |
-| $FF51      | [HDMA1 (CGB Mode only)][linkHDMA1 (CGB Mode only)]         | VRAM DMA source high                                              | W   |
-| $FF52      | [HDMA2 (CGB Mode only)][linkHDMA2 (CGB Mode only)]         | VRAM DMA source low                                               | W   |
-| $FF53      | [HDMA3 (CGB Mode only)][linkHDMA3 (CGB Mode only)]         | VRAM DMA destination high                                         | W   |
-| $FF54      | [HDMA4 (CGB Mode only)][linkHDMA4 (CGB Mode only)]         | VRAM DMA destination low                                          | W   |
-| $FF55      | [HDMA5 (CGB Mode only)][linkHDMA5 (CGB Mode only)]         | VRAM DMA length/mode/start                                        | R/W |
-| $FF56      | [RP (CGB Mode only)][linkRP (CGB Mode only)]               | Infrared communications port                                      | R/W |
-| $FF68      | [BCPS/BGPI (CGB Mode only)][linkBCPS/BGPI (CGB Mode only)] | Background color palette specification / Background palette index | R/W |
-| $FF69      | [BCPD/BGPD (CGB Mode only)][linkBCPD/BGPD (CGB Mode only)] | Background color palette data / Background palette data           | R/W |
-| $FF6A      | [OCPS/OBPI (CGB Mode only)][linkOCPS/OBPI (CGB Mode only)] | OBJ color palette specification / OBJ palette index               | R/W |
-| $FF6B      | [OCPD/OBPD (CGB Mode only)][linkOCPD/OBPD (CGB Mode only)] | OBJ color palette data / OBJ palette data                         | R/W |
-| $FF6C      | [OPRI (CGB Mode only)][linkOPRI (CGB Mode only)]           | Object priority mode                                              | R/W |
-| $FF70      | [SVBK (CGB Mode only)][linkSVBK (CGB Mode only)]           | WRAM bank                                                         | R/W |
-| $FF76      | [PCM12 (CGB Mode only)][linkPCM12 (CGB Mode only)]         | Digital outputs 1 & 2                                             | R   |
-| $FF77      | [PCM34 (CGB Mode only)][linkPCM34 (CGB Mode only)]         | Digital outputs 3 & 4                                             | R   |
-| $FFFF      | [IE][linkIE]                                               | Interrupt enable                                                  | R/W |
+| Addr       | Name                                                   | Description                                                       | R/W |
+|:-----------|--------------------------------------------------------|-------------------------------------------------------------------|-----|
+| $FF00      | [P1/JOYP][P1/JOYP]                                     | Joypad                                                            | R/W |
+| $FF01      | [SB][SB]                                               | Serial transfer data                                              | R/W |
+| $FF02      | [SC][SC]                                               | Serial transfer control                                           | R/W |
+| $FF04      | [DIV][DIV]                                             | Divider register                                                  | R/W |
+| $FF05      | [TIMA][TIMA]                                           | Timer counter                                                     | R/W |
+| $FF06      | [TMA][TMA]                                             | Timer modulo                                                      | R/W |
+| $FF07      | [TAC][TAC]                                             | Timer control                                                     | R/W |
+| $FF0F      | [IF][IF]                                               | Interrupt flag                                                    | R/W |
+| $FF10      | [NR10][NR10]                                           | Channel 1 sweep                                                   | R/W |
+| $FF11      | [NR11][NR11]                                           | Channel 1 length timer & duty cycle                               | R/W |
+| $FF12      | [NR12][NR12]                                           | Channel 1 volume & envelope                                       | R/W |
+| $FF13      | [NR13][NR13]                                           | Channel 1 wavelength low                                          | W   |
+| $FF14      | [NR14][NR14]                                           | Channel 1 wavelength high & control                               | R/W |
+| $FF16      | [NR21][NR21]                                           | Channel 2 length timer & duty cycle                               | R/W |
+| $FF17      | [NR22][NR22]                                           | Channel 2 volume & envelope                                       | R/W |
+| $FF18      | [NR23][NR23]                                           | Channel 2 wavelength low                                          | W   |
+| $FF19      | [NR24][NR24]                                           | Channel 2 wavelength high & control                               | R/W |
+| $FF1A      | [NR30][NR30]                                           | Channel 3 DAC enable                                              | R/W |
+| $FF1B      | [NR31][NR31]                                           | Channel 3 length timer                                            | W   |
+| $FF1C      | [NR32][NR32]                                           | Channel 3 output level                                            | R/W |
+| $FF1D      | [NR33][NR33]                                           | Channel 3 wavelength low                                          | W   |
+| $FF1E      | [NR34][NR34]                                           | Channel 3 wavelength high & control                               | R/W |
+| $FF20      | [NR41][NR41]                                           | Channel 4 length timer                                            | W   |
+| $FF21      | [NR42][NR42]                                           | Channel 4 volume & envelope                                       | R/W |
+| $FF22      | [NR43][NR43]                                           | Channel 4 frequency & randomness                                  | R/W |
+| $FF23      | [NR44][NR44]                                           | Channel 4 control                                                 | R/W |
+| $FF24      | [NR50][NR50]                                           | Master volume & VIN panning                                       | R/W |
+| $FF25      | [NR51][NR51]                                           | Sound panning                                                     | R/W |
+| $FF26      | [NR52][NR52]                                           | Sound on/off                                                      | R/W |
+| $FF30-FF3F | [Wave pattern ram][Wave pattern ram]                   | Wave pattern RAM                                                  | R/W |
+| $FF40      | [LCDC][LCDC]                                           | LCD control                                                       | R/W |
+| $FF41      | [STAT][STAT]                                           | LCD status                                                        | R/W |
+| $FF42      | [SCY][SCY]                                             | Viewport Y position                                               | R/W |
+| $FF43      | [SCX][SCX]                                             | Viewport X position                                               | R/W |
+| $FF44      | [LY][LY]                                               | LCD Y coordinate                                                  | R   |
+| $FF45      | [LYC][LYC]                                             | LY compare                                                        | R/W |
+| $FF46      | [DMA][DMA]                                             | OAM DMA source address & start                                    | R/W |
+| $FF47      | [BGP (Non-CGB Mode only)][BGP (Non-CGB Mode only)]     | BG palette data                                                   | R/W |
+| $FF48      | [OBP0 (Non-CGB Mode only)][OBP0 (Non-CGB Mode only)]   | OBJ palette 0 data                                                | R/W |
+| $FF49      | [OBP1 (Non-CGB Mode only)][OBP1 (Non-CGB Mode only)]   | OBJ palette 1 data                                                | R/W |
+| $FF4A      | [WY][WY]                                               | Window Y position                                                 | R/W |
+| $FF4B      | [WX][WX]                                               | Window X position plus 7                                          | R/W |
+| $FF4D      | [KEY1 (CGB Mode only)][KEY1 (CGB Mode only)]           | Prepare speed switch                                              | R/W |
+| $FF4F      | [VBK (CGB Mode only)][VBK (CGB Mode only)]             | VRAM bank                                                         | R/W |
+| $FF51      | [HDMA1 (CGB Mode only)][HDMA1 (CGB Mode only)]         | VRAM DMA source high                                              | W   |
+| $FF52      | [HDMA2 (CGB Mode only)][HDMA2 (CGB Mode only)]         | VRAM DMA source low                                               | W   |
+| $FF53      | [HDMA3 (CGB Mode only)][HDMA3 (CGB Mode only)]         | VRAM DMA destination high                                         | W   |
+| $FF54      | [HDMA4 (CGB Mode only)][HDMA4 (CGB Mode only)]         | VRAM DMA destination low                                          | W   |
+| $FF55      | [HDMA5 (CGB Mode only)][HDMA5 (CGB Mode only)]         | VRAM DMA length/mode/start                                        | R/W |
+| $FF56      | [RP (CGB Mode only)][RP (CGB Mode only)]               | Infrared communications port                                      | R/W |
+| $FF68      | [BCPS/BGPI (CGB Mode only)][BCPS/BGPI (CGB Mode only)] | Background color palette specification / Background palette index | R/W |
+| $FF69      | [BCPD/BGPD (CGB Mode only)][BCPD/BGPD (CGB Mode only)] | Background color palette data / Background palette data           | R/W |
+| $FF6A      | [OCPS/OBPI (CGB Mode only)][OCPS/OBPI (CGB Mode only)] | OBJ color palette specification / OBJ palette index               | R/W |
+| $FF6B      | [OCPD/OBPD (CGB Mode only)][OCPD/OBPD (CGB Mode only)] | OBJ color palette data / OBJ palette data                         | R/W |
+| $FF6C      | [OPRI (CGB Mode only)][OPRI (CGB Mode only)]           | Object priority mode                                              | R/W |
+| $FF70      | [SVBK (CGB Mode only)][SVBK (CGB Mode only)]           | WRAM bank                                                         | R/W |
+| $FF76      | [PCM12 (CGB Mode only)][PCM12 (CGB Mode only)]         | Digital outputs 1 & 2                                             | R   |
+| $FF77      | [PCM34 (CGB Mode only)][PCM34 (CGB Mode only)]         | Digital outputs 3 & 4                                             | R   |
+| $FFFF      | [IE][IE]                                               | Interrupt enable                                                  | R/W |
 
-[linkP1/JOYP]: ./Joypad_Input.html#ff00--p1joyp-joypad
-[linkSB]: ./Serial_Data_Transfer_(Link_Cable).html#ff01--sb-serial-transfer-data
-[linkSC]: ./Serial_Data_Transfer_(Link_Cable).html#ff02--sc-serial-transfer-control
-[linkDIV]: ./Timer_and_Divider_Registers.html#ff04--div-divider-register
-[linkTIMA]: ./Timer_and_Divider_Registers.html#ff05--tima-timer-counter
-[linkTMA]: ./Timer_and_Divider_Registers.html#ff06--tma-timer-modulo
-[linkTAC]: ./Timer_and_Divider_Registers.html#ff07--tac-timer-control
-[linkIF]: ./Interrupts.html#ff0f--if-interrupt-flag
-[linkNR10]: ./Audio_Registers.html#ff10--nr10-channel-1-sweep
-[linkNR11]: ./Audio_Registers.html#ff11--nr11-channel-1-length-timer--duty-cycle
-[linkNR12]: ./Audio_Registers.html#ff12--nr12-channel-1-volume--envelope
-[linkNR13]: ./Audio_Registers.html#ff13--nr13-channel-1-wavelength-low-write-only
-[linkNR14]: ./Audio_Registers.html#ff14--nr14-channel-1-wavelength-high--control
-[linkNR21]: ./Audio_Registers.html#sound-channel-2--pulse
-[linkNR22]: ./Audio_Registers.html#sound-channel-2--pulse
-[linkNR23]: ./Audio_Registers.html#sound-channel-2--pulse
-[linkNR24]: ./Audio_Registers.html#sound-channel-2--pulse
-[linkNR30]: ./Audio_Registers.html#ff1a--nr30-channel-3-dac-enable
-[linkNR31]: ./Audio_Registers.html#ff1b--nr31-channel-3-length-timer-write-only
-[linkNR32]: ./Audio_Registers.html#ff1c--nr32-channel-3-output-level
-[linkNR33]: ./Audio_Registers.html#ff1d--nr33-channel-3-wavelength-low-write-only
-[linkNR34]: ./Audio_Registers.html#ff1e--nr34-channel-3-wavelength-high--control
-[linkNR41]: ./Audio_Registers.html#ff20--nr41-channel-4-length-timer-write-only
-[linkNR42]: ./Audio_Registers.html#ff21--nr42-channel-4-volume--envelope
-[linkNR43]: ./Audio_Registers.html#ff22--nr43-channel-4-frequency--randomness
-[linkNR44]: ./Audio_Registers.html#ff23--nr44-channel-4-control
-[linkNR50]: ./Audio_Registers.html#ff24--nr50-master-volume--vin-panning
-[linkNR51]: ./Audio_Registers.html#ff25--nr51-sound-panning
-[linkNR52]: ./Audio_Registers.html#ff26--nr52-sound-onoff
-[linkWave pattern RAM]: ./Audio_Registers.html#ff30ff3f--wave-pattern-ram
-[linkLCDC]: ./LCDC.html#ff40--lcdc-lcd-control
-[linkSTAT]: ./STAT.html#ff41--stat-lcd-status
-[linkSCY]: ./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position
-[linkSCX]: ./Scrolling.html#ff42ff43--scy-scx-viewport-y-position-x-position
-[linkLY]: ./Scrolling.html#ff44--ly-lcd-y-coordinate-read-only
-[linkLYC]: ./Scrolling.html#ff45--lyc-ly-compare
-[linkDMA]: ./OAM_DMA_Transfer.html#ff46--dma-oam-dma-source-address--start
-[linkBGP (Non-CGB Mode only)]: ./Palettes.html#ff47--bgp-non-cgb-mode-only-bg-palette-data
-[linkOBP0 (Non-CGB Mode only)]: ./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data
-[linkOBP1 (Non-CGB Mode only)]: ./Palettes.html#ff48ff49--obp0-obp1-non-cgb-mode-only-obj-palette-0-1-data
-[linkWY]: ./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7
-[linkWX]: ./Scrolling.html#ff4aff4b--wy-wx-window-y-position-x-position-plus-7
-[linkKEY1 (CGB Mode only)]: ./CGB_Registers.html#ff4d--key1-cgb-mode-only-prepare-speed-switch
-[linkVBK (CGB Mode only)]: ./CGB_Registers.html#ff4f--vbk-cgb-mode-only-vram-bank
-[linkHDMA1 (CGB Mode only)]: ./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only
-[linkHDMA2 (CGB Mode only)]: ./CGB_Registers.html#ff51ff52--hdma1-hdma2-cgb-mode-only-vram-dma-source-high-low-write-only
-[linkHDMA3 (CGB Mode only)]: ./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only
-[linkHDMA4 (CGB Mode only)]: ./CGB_Registers.html#ff53ff54--hdma3-hdma4-cgb-mode-only-vram-dma-destination-high-low-write-only
-[linkHDMA5 (CGB Mode only)]: ./CGB_Registers.html#ff55--hdma5-cgb-mode-only-vram-dma-lengthmodestart
-[linkRP (CGB Mode only)]: ./CGB_Registers.html#ff56--rp-cgb-mode-only-infrared-communications-port
-[linkBCPS/BGPI (CGB Mode only)]: ./Palettes.html#ff68--bcpsbgpi-cgb-mode-only-background-color-palette-specification--background-palette-index
-[linkBCPD/BGPD (CGB Mode only)]: ./Palettes.html#ff69--bcpdbgpd-cgb-mode-only-background-color-palette-data--background-palette-data
-[linkOCPS/OBPI (CGB Mode only)]: ./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data
-[linkOCPD/OBPD (CGB Mode only)]: ./Palettes.html#ff6aff6b--ocpsobpi-ocpdobpd-cgb-mode-only-obj-color-palette-specification--obj-palette-index-obj-color-palette-data--obj-palette-data
-[linkOPRI (CGB Mode only)]: ./CGB_Registers.html#ff6c--opri-cgb-mode-only-object-priority-mode
-[linkSVBK (CGB Mode only)]: ./CGB_Registers.html#ff70--svbk-cgb-mode-only-wram-bank
-[linkPCM12 (CGB Mode only)]: ./Audio_details.html#ff76--pcm12-cgb-mode-only-digital-outputs-1--2-read-only
-[linkPCM34 (CGB Mode only)]: ./Audio_details.html#ff77--pcm34-cgb-mode-only-digital-outputs-3--4-read-only
-[linkIE]: ./Interrupts.html#ffff--ie-interrupt-enable
+[P1/JOYP]: <#FF00 — P1/JOYP: Joypad>
+[SB]: <#FF01 — SB: Serial transfer data>
+[SC]: <#FF02 — SC: Serial transfer control>
+[DIV]: <#FF04 — DIV: Divider register>
+[TIMA]: <#FF05 — TIMA: Timer counter>
+[TMA]: <#FF06 — TMA: Timer modulo>
+[TAC]: <#FF07 — TAC: Timer control>
+[IF]: <#FF0F — IF: Interrupt flag>
+[NR10]: <#FF10 — NR10: Channel 1 sweep>
+[NR11]: <#FF11 — NR11: Channel 1 length timer & duty cycle>
+[NR12]: <#FF12 — NR12: Channel 1 volume & envelope>
+[NR13]: <#FF13 — NR13: Channel 1 wavelength low \[write-only\]>
+[NR14]: <#FF14 — NR14: Channel 1 wavelength high & control>
+[NR21]: <#Sound Channel 2 — Pulse>
+[NR22]: <#Sound Channel 2 — Pulse>
+[NR23]: <#Sound Channel 2 — Pulse>
+[NR24]: <#Sound Channel 2 — Pulse>
+[NR30]: <#FF1A — NR30: Channel 3 DAC enable>
+[NR31]: <#FF1B — NR31: Channel 3 length timer \[write-only\]>
+[NR32]: <#FF1C — NR32: Channel 3 output level>
+[NR33]: <#FF1D — NR33: Channel 3 wavelength low \[write-only\]>
+[NR34]: <#FF1E — NR34: Channel 3 wavelength high & control>
+[NR41]: <#FF20 — NR41: Channel 4 length timer \[write-only\]>
+[NR42]: <#FF21 — NR42: Channel 4 volume & envelope>
+[NR43]: <#FF22 — NR43: Channel 4 frequency & randomness>
+[NR44]: <#FF23 — NR44: Channel 4 control>
+[NR50]: <#FF24 — NR50: Master volume & VIN panning>
+[NR51]: <#FF25 — NR51: Sound panning>
+[NR52]: <#FF26 — NR52: Sound on/off>
+[Wave pattern RAM]: <#FF30–FF3F — Wave pattern RAM>
+[LCDC]: <#FF40 — LCDC: LCD control>
+[STAT]: <#FF41 — STAT: LCD status>
+[SCY]: <#FF42–FF43 — SCY, SCX: Viewport Y position, X position>
+[SCX]: <#FF42–FF43 — SCY, SCX: Viewport Y position, X position>
+[LY]: <#FF44 — LY: LCD Y coordinate \[read-only\]>
+[LYC]: <#FF45 — LYC: LY compare>
+[DMA]: <#FF46 — DMA: OAM DMA source address & start>
+[BGP (Non-CGB Mode only)]: <#FF47 — BGP (Non-CGB Mode only): BG palette data>
+[OBP0 (Non-CGB Mode only)]: <#FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data>
+[OBP1 (Non-CGB Mode only)]: <#FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data>
+[WY]: <#FF4A–FF4B — WY, WX: Window Y position, X position plus 7>
+[WX]: <#FF4A–FF4B — WY, WX: Window Y position, X position plus 7>
+[KEY1 (CGB Mode only)]: <#FF4D — KEY1 (CGB Mode only): Prepare speed switch>
+[VBK (CGB Mode only)]: <#FF4F — VBK (CGB Mode only): VRAM bank>
+[HDMA1 (CGB Mode only)]: <#FF51–FF52 — HDMA1, HDMA2 (CGB Mode only): VRAM DMA source (high, low) \[write-only\]>
+[HDMA2 (CGB Mode only)]: <#FF51–FF52 — HDMA1, HDMA2 (CGB Mode only): VRAM DMA source (high, low) \[write-only\]>
+[HDMA3 (CGB Mode only)]: <#FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]>
+[HDMA4 (CGB Mode only)]: <#FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]>
+[HDMA5 (CGB Mode only)]: <#FF55 — HDMA5 (CGB Mode only): VRAM DMA length/mode/start>
+[RP (CGB Mode only)]: <#FF56 — RP (CGB Mode only): Infrared communications port>
+[BCPS/BGPI (CGB Mode only)]: <#FF68 — BCPS/BGPI (CGB Mode only): Background color palette specification / Background palette index>
+[BCPD/BGPD (CGB Mode only)]: <#FF69 — BCPD/BGPD (CGB Mode only): Background color palette data / Background palette data>
+[OCPS/OBPI (CGB Mode only)]: <#FF6A–FF6B — OCPS/OBPI, OCPD/OBPD (CGB Mode only): OBJ color palette specification / OBJ palette index, OBJ color palette data / OBJ palette data>
+[OCPD/OBPD (CGB Mode only)]: <#FF6A–FF6B — OCPS/OBPI, OCPD/OBPD (CGB Mode only): OBJ color palette specification / OBJ palette index, OBJ color palette data / OBJ palette data>
+[OPRI (CGB Mode only)]: <#FF6C — OPRI (CGB Mode only): Object priority mode>
+[SVBK (CGB Mode only)]: <#FF70 — SVBK (CGB Mode only): WRAM bank>
+[PCM12 (CGB Mode only)]: <#FF76 — PCM12 (CGB Mode only): Digital outputs 1 & 2 \[read-only\]>
+[PCM34 (CGB Mode only)]: <#FF77 — PCM34 (CGB Mode only): Digital outputs 3 & 4 \[read-only\]>
+[IE]: <#FFFF — IE: Interrupt enable>

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -11,24 +11,24 @@ $FF05      | [TIMA]             | Timer counter                                 
 $FF06      | [TMA]              | Timer modulo                                                      | R/W                 | All
 $FF07      | [TAC]              | Timer control                                                     | R/W                 | All
 $FF0F      | [IF]               | Interrupt flag                                                    | R/W                 | All
-$FF10      | [NR10]             | Channel 1 sweep                                                   | R/W                 | All
-$FF11      | [NR11]             | Channel 1 length timer & duty cycle                               | Mixed               | All
-$FF12      | [NR12]             | Channel 1 volume & envelope                                       | R/W                 | All
-$FF13      | [NR13]             | Channel 1 wavelength low                                          | W                   | All
-$FF14      | [NR14]             | Channel 1 wavelength high & control                               | Mixed               | All
-$FF16      | [NR21]             | Channel 2 length timer & duty cycle                               | Mixed               | All
-$FF17      | [NR22]             | Channel 2 volume & envelope                                       | R/W                 | All
-$FF18      | [NR23]             | Channel 2 wavelength low                                          | W                   | All
-$FF19      | [NR24]             | Channel 2 wavelength high & control                               | Mixed               | All
-$FF1A      | [NR30]             | Channel 3 DAC enable                                              | R/W                 | All
-$FF1B      | [NR31]             | Channel 3 length timer                                            | W                   | All
-$FF1C      | [NR32]             | Channel 3 output level                                            | R/W                 | All
-$FF1D      | [NR33]             | Channel 3 wavelength low                                          | W                   | All
-$FF1E      | [NR34]             | Channel 3 wavelength high & control                               | Mixed               | All
-$FF20      | [NR41]             | Channel 4 length timer                                            | W                   | All
-$FF21      | [NR42]             | Channel 4 volume & envelope                                       | R/W                 | All
-$FF22      | [NR43]             | Channel 4 frequency & randomness                                  | R/W                 | All
-$FF23      | [NR44]             | Channel 4 control                                                 | Mixed               | All
+$FF10      | [NR10]             | Sound channel 1 sweep                                            | R/W                 | All
+$FF11      | [NR11]             | Sound channel 1 length timer & duty cycle                        | Mixed               | All
+$FF12      | [NR12]             | Sound channel 1 volume & envelope                                | R/W                 | All
+$FF13      | [NR13]             | Sound channel 1 wavelength low                                   | W                   | All
+$FF14      | [NR14]             | Sound channel 1 wavelength high & control                        | Mixed               | All
+$FF16      | [NR21]             | Sound channel 2 length timer & duty cycle                        | Mixed               | All
+$FF17      | [NR22]             | Sound channel 2 volume & envelope                                | R/W                 | All
+$FF18      | [NR23]             | Sound channel 2 wavelength low                                   | W                   | All
+$FF19      | [NR24]             | Sound channel 2 wavelength high & control                        | Mixed               | All
+$FF1A      | [NR30]             | Sound channel 3 DAC enable                                       | R/W                 | All
+$FF1B      | [NR31]             | Sound channel 3 length timer                                     | W                   | All
+$FF1C      | [NR32]             | Sound channel 3 output level                                     | R/W                 | All
+$FF1D      | [NR33]             | Sound channel 3 wavelength low                                   | W                   | All
+$FF1E      | [NR34]             | Sound channel 3 wavelength high & control                        | Mixed               | All
+$FF20      | [NR41]             | Sound channel 4 length timer                                     | W                   | All
+$FF21      | [NR42]             | Sound channel 4 volume & envelope                                | R/W                 | All
+$FF22      | [NR43]             | Sound channel 4 frequency & randomness                           | R/W                 | All
+$FF23      | [NR44]             | Sound channel 4 control                                          | Mixed               | All
 $FF24      | [NR50]             | Master volume & VIN panning                                       | R/W                 | All
 $FF25      | [NR51]             | Sound panning                                                     | R/W                 | All
 $FF26      | [NR52]             | Sound on/off                                                      | Mixed               | All

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,7 +14,7 @@
 
 # I/O Ports
 
-- [Hardware Registers](./Hardware_Reg_List.md)
+- [Summary](./Hardware_Reg_List.md)
 - [Rendering](./Rendering.md)
   - [Tile Data](./Tile_Data.md)
   - [Tile Maps](./Tile_Maps.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,6 +14,7 @@
 
 # I/O Ports
 
+- [Hardware Registers](./Hardware_Reg_List.md)
 - [Rendering](./Rendering.md)
   - [Tile Data](./Tile_Data.md)
   - [Tile Maps](./Tile_Maps.md)


### PR DESCRIPTION
* R/W taken from the regs section name, they may need correcting
* Should wave ram be included (and if so, in this format)?
* Potential CGB/Non-CGB columns?

Fixes https://github.com/gbdev/pandocs/issues/399