### PR TITLE
Move ly lyc to stat page

### DIFF
--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -180,7 +180,7 @@ And the following will keep operating as usual:
 The CPU stops for 2050 cycles (= 8200 clocks) after the `stop` instruction is
 executed. During this time, the CPU is in a strange state. `DIV` does not tick, so
 *some* audio events are not processed. Additionally, VRAM/OAM/... locking is "frozen", yielding
-different results depending on the [STAT mode](<#FF41 — STAT: LCD status>) it's started in:
+different results depending on the [STAT mode](<#STAT modes>) it's started in:
 
 - HBlank / VBlank (Mode 0 / Mode 1): The PPU cannot access any video memory, and produces black pixels
 - OAM scan (Mode 2): The PPU can access VRAM just fine, but not OAM, leading to rendering background, but not sprites

--- a/src/Interrupt_Sources.md
+++ b/src/Interrupt_Sources.md
@@ -2,7 +2,7 @@
 
 ## INT $40 — VBlank interrupt
 
-This interrupt is requested every time the Game Boy enters VBlank ([Mode 1](<#FF41 — STAT: LCD status>)).
+This interrupt is requested every time the Game Boy enters VBlank ([Mode 1](<#STAT modes>)).
 
 The VBlank interrupt occurs ca. 59.7 times a second on a handheld Game
 Boy (DMG or CGB) or Game Boy Player and ca. 61.1 times a second on a

--- a/src/OAM.md
+++ b/src/OAM.md
@@ -62,7 +62,7 @@ The recommended method is to write the data to a buffer in normal RAM
 
 While it is also possible to write data directly to the OAM area
 [by accessing it normally](<#OAM (memory area at $FE00-$FE9F) is accessible during Modes 0-1>),
-this only works [during the HBlank and VBlank periods](<#FF41 — STAT: LCD status>).
+this only works [during the HBlank and VBlank periods](<#STAT modes>).
 
 ## Object Priority and Conflicts
 

--- a/src/OAM.md
+++ b/src/OAM.md
@@ -62,7 +62,7 @@ The recommended method is to write the data to a buffer in normal RAM
 
 While it is also possible to write data directly to the OAM area
 [by accessing it normally](<#OAM (memory area at $FE00-$FE9F) is accessible during Modes 0-1>),
-this only works [during the HBlank and VBlank periods](<#LCD Status Register>).
+this only works [during the HBlank and VBlank periods](<#FF41 — STAT: LCD status>).
 
 ## Object Priority and Conflicts
 

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -72,7 +72,7 @@ Bit 10-14 Blue Intensity  ($00-1F)
 ```
 
 Much like VRAM, data in palette memory cannot be read or written during the time
-when the PPU is reading from it, that is, [Mode 3](<#FF41 — STAT: LCD status>).
+when the PPU is reading from it, that is, [Mode 3](<#STAT modes>).
 
 ::: tip NOTE
 

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -72,7 +72,7 @@ Bit 10-14 Blue Intensity  ($00-1F)
 ```
 
 Much like VRAM, data in palette memory cannot be read or written during the time
-when the PPU is reading from it, that is, [Mode 3](<#LCD Status Register>).
+when the PPU is reading from it, that is, [Mode 3](<#FF41 — STAT: LCD status>).
 
 ::: tip NOTE
 

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -14,7 +14,7 @@ values from 144 to 153 indicating the VBlank period.
 
 ## FF45 — LYC: LY compare
 
-The Game Boy permanently compares the value of the LYC and LY registers.
+The Game Boy constantly compares the value of the LYC and LY registers.
 When both values are identical, the "LYC=LY" flag in the STAT register
 is set, and (if enabled) a STAT interrupt is requested.
 

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -1,4 +1,4 @@
-# LCD Status Register
+# LCD Status Registers
 
 ::: tip TERMINOLOGY
 

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -40,6 +40,8 @@ It is constantly updated.
 
 Bits 3-6 select which sources are used for [the STAT interrupt](<#INT $48 — STAT interrupt>).
 
+## STAT modes
+
 The LCD controller operates on a 2^22 Hz = 4.194 MHz dot clock. An
 entire frame is 154 scanlines = 70224 dots = 16.74 ms. On scanlines 0
 through 143, the PPU cycles through modes 2, 3, and 0 once

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -1,4 +1,4 @@
-# LCD Status Registers
+# LCD Status Register
 
 ## FF44 — LY: LCD Y coordinate \[read-only\]
 

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -1,4 +1,16 @@
-# LCD Status Register
+# LCD Status Registers
+
+## FF44 — LY: LCD Y coordinate \[read-only\]
+
+LY indicates the current horizontal line, which might be about to be drawn,
+being drawn, or just been drawn. LY can hold any value from 0 to 153, with
+values from 144 to 153 indicating the VBlank period.
+
+## FF45 — LYC: LY compare
+
+The Game Boy permanently compares the value of the LYC and LY registers.
+When both values are identical, the "LYC=LY" flag in the STAT register
+is set, and (if enabled) a STAT interrupt is requested.
 
 ::: tip TERMINOLOGY
 

--- a/src/STAT.md
+++ b/src/STAT.md
@@ -1,5 +1,11 @@
 # LCD Status Register
 
+::: tip TERMINOLOGY
+
+A *dot* is the shortest period over which the PPU can output one pixel: is it equivalent to 1 T-state on DMG or on CGB single-speed mode or 2 T-states on CGB double-speed mode. On each dot during mode 3, either the PPU outputs a pixel or the fetcher is stalling the [FIFOs](<#Pixel FIFO>).
+
+:::
+
 ## FF44 — LY: LCD Y coordinate \[read-only\]
 
 LY indicates the current horizontal line, which might be about to be drawn,
@@ -11,12 +17,6 @@ values from 144 to 153 indicating the VBlank period.
 The Game Boy permanently compares the value of the LYC and LY registers.
 When both values are identical, the "LYC=LY" flag in the STAT register
 is set, and (if enabled) a STAT interrupt is requested.
-
-::: tip TERMINOLOGY
-
-A *dot* is the shortest period over which the PPU can output one pixel: is it equivalent to 1 T-state on DMG or on CGB single-speed mode or 2 T-states on CGB double-speed mode. On each dot during mode 3, either the PPU outputs a pixel or the fetcher is stalling the [FIFOs](<#Pixel FIFO>).
-
-:::
 
 ## FF41 — STAT: LCD status
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -21,7 +21,7 @@
   - [OAM](./OAM.md)
     - [OAM DMA Transfer](./OAM_DMA_Transfer.md)
   - [LCD Control](./LCDC.md)
-  - [LCD Status](./STAT.md)
+  - [LCD Status Registers](./STAT.md)
   - [Scrolling](./Scrolling.md)
   - [Palettes](./Palettes.md)
   - [Pixel FIFO](./pixel_fifo.md)

--- a/src/Scrolling.md
+++ b/src/Scrolling.md
@@ -9,18 +9,6 @@ effect immediately (see further below).
 Those specify the top-left coordinates of the visible 160×144 pixel area within the
 256×256 pixels BG map. Values in the range 0–255 may be used.
 
-## FF44 — LY: LCD Y coordinate \[read-only\]
-
-LY indicates the current horizontal line, which might be about to be drawn,
-being drawn, or just been drawn. LY can hold any value from 0 to 153, with
-values from 144 to 153 indicating the VBlank period.
-
-## FF45 — LYC: LY compare
-
-The Game Boy permanently compares the value of the LYC and LY registers.
-When both values are identical, the "LYC=LY" flag in the STAT register
-is set, and (if enabled) a STAT interrupt is requested.
-
 ## FF4A–FF4B — WY, WX: Window Y position, X position plus 7
 
 Specify the top-left coordinates of [the Window](#Window).

--- a/src/Tile_Maps.md
+++ b/src/Tile_Maps.md
@@ -99,7 +99,7 @@ Whether the Window is displayed can be toggled using
 [LCDC bit 5](<#LCDC.5 — Window enable>). But in Non-CGB mode this bit is only
 functional as long as [LCDC bit 0](<#LCDC.0 — BG and Window enable/priority>) is set.
 Enabling the Window makes
-[Mode 3](<#FF41 — STAT: LCD status>) slightly longer on scanlines where it's visible.
+[Mode 3](<#STAT modes>) slightly longer on scanlines where it's visible.
 (See [WX and WY](<#FF4A–FF4B — WY, WX: Window Y position, X position plus 7>)
 for the definition of "Window visibility".)
 

--- a/src/Tile_Maps.md
+++ b/src/Tile_Maps.md
@@ -99,7 +99,7 @@ Whether the Window is displayed can be toggled using
 [LCDC bit 5](<#LCDC.5 — Window enable>). But in Non-CGB mode this bit is only
 functional as long as [LCDC bit 0](<#LCDC.0 — BG and Window enable/priority>) is set.
 Enabling the Window makes
-[Mode 3](<#LCD Status Register>) slightly longer on scanlines where it's visible.
+[Mode 3](<#FF41 — STAT: LCD status>) slightly longer on scanlines where it's visible.
 (See [WX and WY](<#FF4A–FF4B — WY, WX: Window Y position, X position plus 7>)
 for the definition of "Window visibility".)
 


### PR DESCRIPTION
Closes https://github.com/gbdev/pandocs/issues/439

I decided on putting these on top of STAT as they're mentioned in sentence 2 of STAT's description, so it's fresh info

Maybe title needs changing? Though LCD Status Registers feels wrong