### PR TITLE
Border has an extra scanline, visible in some cases

### DIFF
--- a/src/SGB_Command_Border.md
+++ b/src/SGB_Command_Border.md
@@ -91,7 +91,7 @@ Most of the time, SGB hides this extra line with forced blanking (writing $80 to
 While SGB is busy doing some things, such as fading out the border's palette, it neglects to force blanking, making the line flicker on some TVs.
 
 To fully eliminate flicker, write a row of all-black tilemap entries after the bottom row of the border ($8700-$873F in VRAM in a PCT_TRN), or at least a row of tiles whose top row of pixels is blank.
-If that is not convenient, such as if a border data format doesn't guarantee an all-black tile ID, you can make the flicker less objectionable by repeating the last scanline.
+If that is not convenient, such as if a border data format doesn't guarantee an all-black tile ID, you can make the flicker less noticeable by repeating the last scanline.
 Take the bottommost row (at $86C0-$86FF in VRAM) and copy it to the extra row, flipped vertically (XOR with $8000).
 
 The Super NES supports 8 background palettes.

--- a/src/SGB_Command_Border.md
+++ b/src/SGB_Command_Border.md
@@ -88,7 +88,8 @@ It turns out that 29 rows of the border tilemap sent through PCT_TRN are at leas
 The SGB system software sets the border layer's vertical scroll position (BG1VOFS) to 0.
 Because the S-PPU normally displays lines BGxVOFS+1 through BGxVOFS+224 of each layer, this hides the first scanline of the top row of tiles and adds one scanline of the nominally invisible 29th row at the bottom.
 Most of the time, SGB hides this extra line with forced blanking (writing $80 to INIDISP at address $012100).
-While SGB is busy doing some things, such as fading out the border's palette, it neglects to force blanking, making the line flicker on some TVs.
+While SGB is busy processing some packets, such as fading out the border's palette or loading a new scene's palette and attributes, it neglects to force blanking, making the line flicker on some TVs.
+This can be seen even with some built-in borders.
 
 To fully eliminate flicker, write a row of all-black tilemap entries after the bottom row of the border ($8700-$873F in VRAM in a PCT_TRN), or at least a row of tiles whose top row of pixels is blank.
 If that is not convenient, such as if a border data format doesn't guarantee an all-black tile ID, you can make the flicker less noticeable by repeating the last scanline.


### PR DESCRIPTION
One scanline immediately below the SGB border flickers when SGB is busy.  Explain why, and how to hide it

Related Border Crossing commit:
https://github.com/pinobatch/little-things-gb/commit/a3df90fec2ee37001e5f326e7e3fab92b61ec775