### PR TITLE
OAM DMA: speed, CGB buses, di, mode 1, and no soda

### DIFF
--- a/src/OAM_DMA_Transfer.md
+++ b/src/OAM_DMA_Transfer.md
@@ -3,8 +3,8 @@
 
 ## FF46 — DMA: OAM DMA source address & start
 
-Writing to this register launches a DMA transfer from ROM or RAM to OAM
-(Object Attribute Memory). The written value specifies the
+Writing to this register starts a DMA transfer from ROM or RAM to OAM
+(Object Attribute Memory).  The written value specifies the
 transfer source address divided by $100, that is, source and destination are:
 
 ```
@@ -13,11 +13,10 @@ Destination: $FE00-$FE9F
 ```
 
 The transfer takes 160 machine cycles: 152 microseconds in normal speed
-or 76 microseconds in CGB Double Speed Mode. On DMG, during this time,
-the CPU can access only HRAM (memory at $FF80-$FFFE); on CGB, the bus used
-by the source area cannot be used (this isn't understood well at the
-moment; it's recommended to assume same behavior as DMG). For this
-reason, the programmer must copy a short procedure into HRAM, and use
+or 76 microseconds in CGB Double Speed Mode.
+This is much faster than a CPU-driven copy.
+On DMG, during this time, the CPU can access only HRAM (memory at $FF80-$FFFE).
+For this reason, the programmer must copy a short procedure into HRAM, and use
 this procedure to start the transfer from inside HRAM, and wait until
 the transfer has finished:
 
@@ -32,14 +31,27 @@ run_dma:
     ret
 ```
 
-Because sprites are not displayed while an OAM DMA transfer is in progress, most
-programs execute this procedure from inside their VBlank
+On CGB, the cartridge and WRAM are on separate buses.
+This means that the CPU can access ROM or cartridge SRAM during OAM DMA from WRAM, or WRAM during OAM DMA from ROM or SRAM.
+However, because a `call` writes a return address to the stack, and the stack and variables are usually in WRAM,
+it's still recommended to busy-wait in HRAM for DMA to finish even on CGB.
+
+Caution: An interrupt writes a return address to the stack and fetches the interrupt handler's instructions from ROM.
+This means it's critical to prevent interrupts during OAM DMA,
+especially in a program that uses timer, serial, or joypad interrupts, which are not synchronized to the LCD.
+This can be done by executing DMA within the VBlank interrupt handler or through the `di` instruction.
+
+While an OAM DMA is in progress, the PPU reads $FF from OAM.
+This corresponds to an object that is both vertically and horizontally out of range,
+causing objects not to be displayed while the transfer is in progress.
+Thus most programs execute DMA in Mode 1, inside or immediately after their VBlank
 handler. But it is also possible to execute it during display redraw (Modes 2 and 3),
-allowing to display more than 40 sprites on the screen (that is, for
-example 40 sprites in the top half, and other 40 sprites in the bottom half of
-the screen), at the cost of a couple lines that lack sprites due to the fact that
-during those couple lines the PPU reads OAM as $FF. Besides, graphic glitches may
-happen if an OAM DMA transfer is started during Mode 3.
+allowing to display more than 40 objects on the screen (that is, for
+example 40 objects in the top half, and other 40 objects in the bottom half of
+the screen), at the cost of a couple lines that lack objects.
+It's best to start a mid-screen transfer in Mode 0 because
+if the transfer is started during Mode 3, graphical glitches may happen.
+<!-- TODO: reproducer for glitches being related to the PPU reading tile $FF for objects previously seen in Mode 2 -->
 
 A more compact procedure is
 
@@ -47,9 +59,9 @@ A more compact procedure is
 run_dma:          ; This part is in ROM
     ld a, HIGH(start address)
     ld bc, $2846  ; B: wait time; C: LOW($FF46)
-    jp run_dma_hrampart
+    jp run_dma_tail
 
-run_dma_hrampart:
+run_dma_tail:     ; This part is in HRAM
     ldh [c], a
 .wait
     dec b

--- a/src/OAM_DMA_Transfer.md
+++ b/src/OAM_DMA_Transfer.md
@@ -19,8 +19,8 @@ This is much faster than a CPU-driven copy.
 ## OAM DMA bus conflicts
 
 On DMG, during OAM DMA, the CPU can access only HRAM (memory at $FF80-$FFFE).
-For this reason, the programmer must copy a short procedure into HRAM, and use
-this procedure to start the transfer from inside HRAM, and wait until
+For this reason, the programmer must copy a short procedure (see below) into HRAM, and use
+this procedure to start the transfer **from inside HRAM**, and wait until
 the transfer has finished.
 
 On CGB, the cartridge and WRAM are on separate buses.
@@ -37,7 +37,7 @@ This can be done by executing DMA within the VBlank interrupt handler or through
 :::
 
 While an OAM DMA is in progress, the PPU cannot read OAM properly either.
-Thus most programs execute DMA during [Mode 1](<#STAT modes>), inside or immediately after their VBlank handler.
+Thus, most programs execute DMA during [Mode 1](<#STAT modes>), inside or immediately after their VBlank handler.
 But it is also possible to execute it during display redraw (Modes 2 and 3),
 allowing to display more than 40 objects on the screen (that is, for
 example 40 objects in the top half, and other 40 objects in the bottom half of
@@ -88,6 +88,6 @@ run_dma_tail:     ; This part is in HRAM
     ret
 ```
 
-If starting a mid-screen transfer, wait for Mode 0 first
+If starting a mid-frame transfer, wait for Mode 0 first
 so that the transfer cleanly overlaps Mode 2 on the next two lines,
 making objects invisible on those lines.

--- a/src/OAM_DMA_Transfer.md
+++ b/src/OAM_DMA_Transfer.md
@@ -36,13 +36,16 @@ This means that the CPU can access ROM or cartridge SRAM during OAM DMA from WRA
 However, because a `call` writes a return address to the stack, and the stack and variables are usually in WRAM,
 it's still recommended to busy-wait in HRAM for DMA to finish even on CGB.
 
-Caution: An interrupt writes a return address to the stack and fetches the interrupt handler's instructions from ROM.
-This means it's critical to prevent interrupts during OAM DMA,
-especially in a program that uses timer, serial, or joypad interrupts, which are not synchronized to the LCD.
+::: warning Interrupts
+
+An interrupt writes a return address to the stack and fetches the interrupt handler's instructions from ROM.
+Thus, it's critical to prevent interrupts during OAM DMA, especially in a program that uses timer, serial, or joypad interrupts, since they are not synchronized to the LCD.
 This can be done by executing DMA within the VBlank interrupt handler or through the `di` instruction.
 
+:::
+
 While an OAM DMA is in progress, the PPU cannot read OAM properly either.
-Thus most programs execute DMA in Mode 1, inside or immediately after their VBlank handler.
+Thus most programs execute DMA during [Mode 1](<#STAT modes>), inside or immediately after their VBlank handler.
 But it is also possible to execute it during display redraw (Modes 2 and 3),
 allowing to display more than 40 objects on the screen (that is, for
 example 40 objects in the top half, and other 40 objects in the bottom half of

--- a/src/OAM_DMA_Transfer.md
+++ b/src/OAM_DMA_Transfer.md
@@ -12,10 +12,13 @@ Source:      $XX00-$XX9F   ;XX = $00 to $DF
 Destination: $FE00-$FE9F
 ```
 
-The transfer takes 160 machine cycles: 152 microseconds in normal speed
-or 76 microseconds in CGB Double Speed Mode.
+The transfer takes 160 machine cycles: 640 dots (1.4 lines) in normal speed,
+or 320 dots (0.7 lines) in CGB Double Speed Mode.
 This is much faster than a CPU-driven copy.
-On DMG, during this time, the CPU can access only HRAM (memory at $FF80-$FFFE).
+
+## OAM DMA bus conflicts
+
+On DMG, during OAM DMA, the CPU can access only HRAM (memory at $FF80-$FFFE).
 For this reason, the programmer must copy a short procedure into HRAM, and use
 this procedure to start the transfer from inside HRAM, and wait until
 the transfer has finished:
@@ -28,6 +31,23 @@ run_dma:
 .wait
     dec a           ; 1 cycle
     jr nz, .wait    ; 3 cycles
+    ret
+```
+
+If HRAM is tight, this more compact procedure saves 5 bytes of HRAM
+at the cost of a few cycles spent jumping to the tail in HRAM.
+
+```rgbasm
+run_dma:          ; This part is in ROM
+    ld a, HIGH(start address)
+    ld bc, $2846  ; B: wait time; C: LOW($FF46)
+    jp run_dma_tail
+
+run_dma_tail:     ; This part is in HRAM
+    ldh [c], a
+.wait
+    dec b
+    jr nz, .wait
     ret
 ```
 
@@ -53,25 +73,6 @@ the screen), at the cost of a couple lines that lack objects.
 It's best to start a mid-screen transfer in Mode 0 because
 if the transfer is started during Mode 3, graphical glitches may happen.
 
-A more compact procedure is
-
-```rgbasm
-run_dma:          ; This part is in ROM
-    ld a, HIGH(start address)
-    ld bc, $2846  ; B: wait time; C: LOW($FF46)
-    jp run_dma_tail
-
-run_dma_tail:     ; This part is in HRAM
-    ldh [c], a
-.wait
-    dec b
-    jr nz, .wait
-    ret
-```
-
-This saves 5 bytes of HRAM, but is slightly slower in most cases due to
-the jump to the tail in HRAM.
-
 The details:
 
 * If OAM DMA is active during OAM scan (mode 2), most PPU revisions read each object
@@ -80,4 +81,5 @@ The details:
   the DMA unit is writing to OAM when the object is fetched.
   This causes an incorrect tile number and attributes for objects already determined to be in range.
 
+<!-- TODO: find Hacktix test ROM -->
 <!-- TODO: keep working on "Red from OAM", a reproducer that races the beam to overwrite tile number and attributes of objects previously seen in Mode 2 -->


### PR DESCRIPTION
- Emphasize that DMA is much faster than a CPU copy
- Even though CGB divides cart and WRAM buses, stack and variable inaccessibility still favors waiting
- [You must `di` or else you will die](https://youtu.be/kzFbLtCESRU), which [affected Numism Continue](https://github.com/pinobatch/numism/commit/323d158f699f41e900efd145c76ec2b3b63a7dec)
- Move "PPU reads $FF from OAM during DMA" up to streamline flow
- Remove Coca-Cola soft drink ("sprite" to "object")
- Recommend mode for starting mid-screen OAM DMA

TODO: reproducer for OAM DMA artifacts being related to tile numbers of in-range objects being read as $FF