### PR TITLE
audio: change "wavelength" nomenclature to "period value"

### DIFF
--- a/src/Audio.md
+++ b/src/Audio.md
@@ -75,11 +75,11 @@ When the length timer reaches 64, the channel is turned off.
 ### Frequency
 
 Music notes and audio waves are typically manipulated in terms of **frequency**[^pitch], i.e. how often the signal repeats per second.
-However, as explained above, the Game Boy APU primarily works with durations; thus, **wavelengths** will be used instead of frequency.[^len_raw]
+However, as explained above, the Game Boy APU primarily works with durations; thus, **periods** will be used instead of frequency.[^len_raw]
 
 ::: warning
 
-The term "wavelength" throughout this document does *not* designate the inverse of the frequency, but instead a quantity akin to it.
+The terms "period" and "period value" throughout this document refer to a parameter that has a somewhat nonintuitive relationship with frequency.
 See the description of each NRx3 register for more information.
 
 :::
@@ -105,4 +105,4 @@ There is also **pitch**, which is merely a measure of how we perceive frequency.
 The higher the frequency, the higher the pitch; therefore, pitch will be omitted from the rest of the document.
 
 [^len_raw]:
-Actually, the APU interfaces don't work with any wavelengths either, but with values that are more akin to wavelengths than frequencies.
+Actually, the APU interfaces don't work strictly with periods, but with values that can be thought of as *negative* periods.

--- a/src/Hardware_Reg_List.md
+++ b/src/Hardware_Reg_List.md
@@ -14,17 +14,17 @@ $FF0F      | [IF]        | Interrupt flag                                       
 $FF10      | [NR10]      | Sound channel 1 sweep                                             | R/W                 | All
 $FF11      | [NR11]      | Sound channel 1 length timer & duty cycle                         | Mixed               | All
 $FF12      | [NR12]      | Sound channel 1 volume & envelope                                 | R/W                 | All
-$FF13      | [NR13]      | Sound channel 1 wavelength low                                    | W                   | All
-$FF14      | [NR14]      | Sound channel 1 wavelength high & control                         | Mixed               | All
+$FF13      | [NR13]      | Sound channel 1 period low                                        | W                   | All
+$FF14      | [NR14]      | Sound channel 1 period high & control                             | Mixed               | All
 $FF16      | [NR21]      | Sound channel 2 length timer & duty cycle                         | Mixed               | All
 $FF17      | [NR22]      | Sound channel 2 volume & envelope                                 | R/W                 | All
-$FF18      | [NR23]      | Sound channel 2 wavelength low                                    | W                   | All
-$FF19      | [NR24]      | Sound channel 2 wavelength high & control                         | Mixed               | All
+$FF18      | [NR23]      | Sound channel 2 period low                                        | W                   | All
+$FF19      | [NR24]      | Sound channel 2 period high & control                             | Mixed               | All
 $FF1A      | [NR30]      | Sound channel 3 DAC enable                                        | R/W                 | All
 $FF1B      | [NR31]      | Sound channel 3 length timer                                      | W                   | All
 $FF1C      | [NR32]      | Sound channel 3 output level                                      | R/W                 | All
-$FF1D      | [NR33]      | Sound channel 3 wavelength low                                    | W                   | All
-$FF1E      | [NR34]      | Sound channel 3 wavelength high & control                         | Mixed               | All
+$FF1D      | [NR33]      | Sound channel 3 period low                                        | W                   | All
+$FF1E      | [NR34]      | Sound channel 3 period high & control                             | Mixed               | All
 $FF20      | [NR41]      | Sound channel 4 length timer                                      | W                   | All
 $FF21      | [NR42]      | Sound channel 4 volume & envelope                                 | R/W                 | All
 $FF22      | [NR43]      | Sound channel 4 frequency & randomness                            | R/W                 | All
@@ -74,8 +74,8 @@ $FFFF      | [IE]        | Interrupt enable                                     
 [NR10]: <#FF10 — NR10: Channel 1 sweep>
 [NR11]: <#FF11 — NR11: Channel 1 length timer & duty cycle>
 [NR12]: <#FF12 — NR12: Channel 1 volume & envelope>
-[NR13]: <#FF13 — NR13: Channel 1 wavelength low \[write-only\]>
-[NR14]: <#FF14 — NR14: Channel 1 wavelength high & control>
+[NR13]: <#FF13 — NR13: Channel 1 period low \[write-only\]>
+[NR14]: <#FF14 — NR14: Channel 1 period high & control>
 [NR21]: <#Sound Channel 2 — Pulse>
 [NR22]: <#Sound Channel 2 — Pulse>
 [NR23]: <#Sound Channel 2 — Pulse>
@@ -83,8 +83,8 @@ $FFFF      | [IE]        | Interrupt enable                                     
 [NR30]: <#FF1A — NR30: Channel 3 DAC enable>
 [NR31]: <#FF1B — NR31: Channel 3 length timer \[write-only\]>
 [NR32]: <#FF1C — NR32: Channel 3 output level>
-[NR33]: <#FF1D — NR33: Channel 3 wavelength low \[write-only\]>
-[NR34]: <#FF1E — NR34: Channel 3 wavelength high & control>
+[NR33]: <#FF1D — NR33: Channel 3 period low \[write-only\]>
+[NR34]: <#FF1E — NR34: Channel 3 period high & control>
 [NR41]: <#FF20 — NR41: Channel 4 length timer \[write-only\]>
 [NR42]: <#FF21 — NR42: Channel 4 volume & envelope>
 [NR43]: <#FF22 — NR43: Channel 4 frequency & randomness>

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -356,8 +356,8 @@ The table above was obtained from Mooneye-GB tests [`acceptance/boot_hwio-dmg0`]
 [`NR10`]: <#FF10 — NR10: Channel 1 sweep>
 [`NR11`]: <#FF11 — NR11: Channel 1 length timer & duty cycle>
 [`NR12`]: <#FF12 — NR12: Channel 1 volume & envelope>
-[`NR13`]: <#FF13 — NR13: Channel 1 wavelength low \[write-only\]>
-[`NR14`]: <#FF14 — NR14: Channel 1 wavelength high & control>
+[`NR13`]: <#FF13 — NR13: Channel 1 period low \[write-only\]>
+[`NR14`]: <#FF14 — NR14: Channel 1 period high & control>
 [`NR21`]: <#Sound Channel 2 — Pulse>
 [`NR22`]: <#Sound Channel 2 — Pulse>
 [`NR23`]: <#Sound Channel 2 — Pulse>
@@ -365,8 +365,8 @@ The table above was obtained from Mooneye-GB tests [`acceptance/boot_hwio-dmg0`]
 [`NR30`]: <#FF1A — NR30: Channel 3 DAC enable>
 [`NR31`]: <#FF1B — NR31: Channel 3 length timer \[write-only\]>
 [`NR32`]: <#FF1C — NR32: Channel 3 output level>
-[`NR33`]: <#FF1D — NR33: Channel 3 wavelength low \[write-only\]>
-[`NR34`]: <#FF1E — NR34: Channel 3 wavelength high & control>
+[`NR33`]: <#FF1D — NR33: Channel 3 period low \[write-only\]>
+[`NR34`]: <#FF1E — NR34: Channel 3 period high & control>
 [`NR41`]: <#FF20 — NR41: Channel 4 length timer \[write-only\]>
 [`NR42`]: <#FF21 — NR42: Channel 4 volume & envelope>
 [`NR43`]: <#FF22 — NR43: Channel 4 frequency & randomness>


### PR DESCRIPTION
Long ago, the name of the 11-bit value in NR13-NR14, NR23-NR24, and NR33-NR34 was changed from "frequency", which is wrong, to "wavelength", which is less wrong.  It stuck because nobody objected (consensus by crickets).  Some time later, jvsTSX complained that "wavelength" is confusing because the word is more often understood as the reciprocal of spatial frequency, not temporal frequency.  It was pointed out that documents for other PSGs using a frequency divider also use "period" as the name of the parameter.

Add some worked examples to help readers understand the relationship among period value, period, sample rate, and tone frequency.