### PR TITLE
ci: switch to "deploy-page" action and stop relying on additional branches

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,6 +16,18 @@ on:
   schedule:
     - cron: '42 16 1/7 * *'
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 env:
   MDBOOK_LINKCHECK_VER: 0.7.6
 
@@ -62,43 +74,21 @@ jobs:
       run: |
         mdbook build
 
-    - name: Store final build
-      uses: actions/upload-artifact@v2
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
       with:
-        name: Build output
         path: pandocs/docs/pandocs/
-        if-no-files-found: error
 
   deploy:
     name: Deploy to GitHub pages
+    # Do not run this unless *pushing* to `master`.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    # Do not run this unless *pushing* to `master`
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-    - name: Checkout pandocs/gh-pages
-      uses: actions/checkout@v2
-      with:
-        path: pandocs
-        ref: gh-pages
-
-    - name: Delete all current files
-      run: |
-        rm -vrf pandocs/*
-
-    - name: Unpack build
-      uses: actions/download-artifact@v2
-      with:
-        name: Build output
-        path: pandocs/
-
-    - name: Deploy
-      working-directory: pandocs/
-      run: |
-        git config --local user.name "GitHub Action"
-        git config --global user.email "community@gbdev.io"
-        git remote -v
-        git branch -v
-        git add -A
-        git commit -am 'Update build'
-        git push -v
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This should be more robust and faster (no more branch manipulation), as well as avoiding notifications from pushes to that branch.