### PR TITLE
Switch Twitter link to some Nitter instance

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -44,5 +44,4 @@ exclude = [
 	'print.html', # Do not check the print page, as it is generated separately
 	'single.html', # Do not check the single page, as it is generated separately
 	'http[s]*://problemkaputt\.de', # Skip checking problemkaputt.de, as connection to this domain is generally unreliable
-	'https?://twitter.com', # Thank you Elon Musk.
 ]

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -207,7 +207,7 @@ Rely on it at your own risk.
 ### Common remarks
 
 The console's WRAM and HRAM are random on power-up.
-[Different models tend to exhibit different patterns](https://notabird.site/CasualPkPlayer/status/1409752977812852736), but they are random nonetheless, even depending on factors such as the ambient temperature.
+[Different models tend to exhibit different patterns](https://web.archive.org/web/20220131221108/https://twitter.com/CasualPkPlayer/status/1409752977812852736), but they are random nonetheless, even depending on factors such as the ambient temperature.
 Besides, turning the system off and on again has proven reliable enough [to carry over RAM from one game to another](https://www.youtube.com/watch?v=xayxmTLljr8), so it's not a good idea to rely on it at all.
 
 Emulation of uninitialized RAM is inconsistent: some emulators fill RAM with a constant on startup (typically $00 or $FF), some emulators fully randomize RAM, and others attempt to reproduce the patterns observed on hardware.

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -207,7 +207,7 @@ Rely on it at your own risk.
 ### Common remarks
 
 The console's WRAM and HRAM are random on power-up.
-[Different models tend to exhibit different patterns](https://twitter.com/CasualPkPlayer/status/1409752977812852736), but they are random nonetheless, even depending on factors such as the ambient temperature.
+[Different models tend to exhibit different patterns](https://notabird.site/CasualPkPlayer/status/1409752977812852736), but they are random nonetheless, even depending on factors such as the ambient temperature.
 Besides, turning the system off and on again has proven reliable enough [to carry over RAM from one game to another](https://www.youtube.com/watch?v=xayxmTLljr8), so it's not a good idea to rely on it at all.
 
 Emulation of uninitialized RAM is inconsistent: some emulators fill RAM with a constant on startup (typically $00 or $FF), some emulators fully randomize RAM, and others attempt to reproduce the patterns observed on hardware.


### PR DESCRIPTION
This kind of reverts 3f1c43e, since now we'll know if that link goes down. Twitter cannot be used, since like that commit mentions, Twitter now blocks automation (thanks to a certain Elongated Muskrat), which includes mdbook-linkcheck.

The choice of Nitter instance is motivated by a few points. First, a list of instances is available from Nitter's GitHub wiki (https://github.com/zedeus/nitter/wiki/Instances).

The first parameter in the choice is the region; there are three (3) "anycast" instances, which may (1) reduce latency for readers of Pan Docs, and (2) reduce the load of Pan Docs' link-checking itself (by distributing across several servers behind the anycast). I think, anyway.

One of these instances is not updated, which is not a good sign for reliability either.

Then, it turns out several instances block HTTP HEAD requests like Twitter (but not GET, suggesting it is intentional); of the remaining two, only the chosen one doesn't.