### PR TITLE
Improve SGB border documentation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -42,14 +42,14 @@
   - [Command Packet Transfers](./SGB_Command_Packet.md)
   - [VRAM Transfers](./SGB_VRAM_Transfer.md)
   - [Color Palettes Overview](./SGB_Color_Palettes.md)
-  - [Command Summary](./SGB_Command_Summary.md)
+  - [Command List](./SGB_Command_Summary.md)
     - [Palette Commands](./SGB_Command_Palettes.md)
     - [Color Attribute Commands](./SGB_Command_Attribute.md)
     - [Sound Functions](./SGB_Command_Sound.md)
-  - [System Control Commands](./SGB_Command_System.md)
-  - [Multiplayer Command](./SGB_Command_Multiplayer.md)
-  - [Border and OBJ Commands](./SGB_Command_Border.md)
-  - [Undocumented SGB commands](./SGB_Command_Undocumented.md)
+    - [System Control Commands](./SGB_Command_System.md)
+    - [Multiplayer Command](./SGB_Command_Multiplayer.md)
+    - [Border and OBJ Commands](./SGB_Command_Border.md)
+    - [Undocumented SGB commands](./SGB_Command_Undocumented.md)
 
 # CPU Specifications
 


### PR DESCRIPTION
In particular, fixes #199. I'm not entirely sure about all of the info added here, since I was trying to interpret @pinobatch's results.

This is a draft because I want to also improve the rest of the documentation, including splitting off the wall of text under `PCT_TRN`'s header into other headers.