### PR TITLE
Correct wrong unit in MBC3 RTC reccomendation

### DIFF
--- a/src/MBC3.md
+++ b/src/MBC3.md
@@ -92,5 +92,5 @@ Year-10000-Proof, provided that the cartridge gets used at least every
 
 ### Delays
 
-When accessing the RTC Registers it is recommended to execute a 4ms
-delay (4 Cycles in Normal Speed Mode) between the separate accesses.
+When accessing the RTC Registers, it is recommended to wait 4 µs
+(4 cycles in Normal Speed Mode) between any separate accesses.


### PR DESCRIPTION
It seems that the cycle value was correct, and the seconds were typo'd.

Fixes #496