### PR TITLE
APU: clarify which bits of NR41 are actually used

### DIFF
--- a/src/Audio_Registers.md
+++ b/src/Audio_Registers.md
@@ -357,7 +357,7 @@ By default, the noise will sound close to white; but it can be manipulated to so
 This register controls the channel's [length timer](<#Length timer>).
 
 {{#bits 8 >
-  "NR41" 7-0:"Initial length timer"
+  "NR41" 5-0:"Initial length timer"
 }}
 
 The higher the [length timer](<#Length timer>), the shorter the time before the channel is cut.


### PR DESCRIPTION
the docs that were present gave the misleading impression that NR41 sets an 8-bit timer similar to NR31, and that channel 4's length is counted up to 256 like NR31. but channel 4 counts length up to 64 more like channels 1 and 2, with an initial length set from the low six bits of this register.

(spotted this by going through the above logic, noticing that channel 4 seemed to run too long, and comparing against a few other emulators. i don't actually know what happens with the upper two bits here, if they're ignored, or what.)