### PR TITLE
Remove confusing and redundant wording

### DIFF
--- a/src/Interrupt_Sources.md
+++ b/src/Interrupt_Sources.md
@@ -52,10 +52,8 @@ hidden by the text box.
 
 ## INT $50 — Timer interrupt
 
-Every time that the timer overflows (that is, when [TIMA](<#FF05 — TIMA: Timer counter>) exceeds $FF),
-an interrupt is requested by setting bit 2 in the IF register
-($FF0F). As soon as that interrupt is enabled, the CPU will execute it by
-calling the timer interrupt vector at $0050.
+The timer interrupt is requested every time that the timer overflows
+(that is, when [TIMA](<#FF05 — TIMA: Timer counter>) exceeds $FF).
 
 ## INT $58 — Serial interrupt
 


### PR DESCRIPTION
- Remove confusing wording that seemed to imply that timer interrupts are executed immediately (regardless of priority)
- Remove redundant information about the IF register, which is not present in the descriptions of other interrupts