### PR TITLE
Update requirements.txt file for changes in #452

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /docs/
 /target/
 /env/
+/generated/
+__pycache__/

--- a/book.toml
+++ b/book.toml
@@ -10,15 +10,19 @@ build-dir = "docs"
 create-missing = true # This is kept for convenience, but CI sets it to false
 use-default-preprocessors = false
 
-# Custom preprocessor for internal links processing
-[preprocessor.pandocs]
-command = "cargo run -p pandocs-preproc --locked --release --"
-after = [ "links" ]
+[preprocessor.graph_gen]
+command = "src/imgs/src/preproc.py"
+before = [ "links" ] # This generates some of the files that get `{{#include}}`d
 
 # `{{#include }}` etc. resolution
 [preprocessor.links]
 
-# Custom back-end for our custom markup
+# Custom preprocessor for internal links processing and other custom markup
+[preprocessor.pandocs]
+command = "cargo run -p pandocs-preproc --locked --release --"
+after = [ "links" ]
+
+# Custom back-end to generate the single-file version and scrub off some generated files
 [output.pandocs]
 command = "cargo run -p pandocs-renderer --locked --release --"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-pygal==3.0.0
+beautifulsoup4==4.12.2
+lxml==5.0.0
+matplotlib==3.8.2
+pandas==2.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.12.2
-lxml==5.0.0
-matplotlib==3.8.2
-pandas==2.1.4
+beautifulsoup4>=4.12.2,<=5.0
+lxml>=5.0.0,<=6.0
+matplotlib>=3.8.2,<=4.0
+pandas>=2.1.4,<=3.0

--- a/src/MBC5.md
+++ b/src/MBC5.md
@@ -58,6 +58,6 @@ bit to 1 enables the rumble motor and keeps it enabled until the bit is reset ag
 To control the rumble's intensity, it should be turned on and off repeatedly,
 as seen with these two examples from Pokémon Pinball:
 
-<img src="imgs/MBC5_Rumble_Mild.svg" width="950px">
+{{#include ../generated/MBC5_Rumble_Mild.svg}}
 
-<img src="imgs/MBC5_Rumble_Strong.svg" width="950px">
+{{#include ../generated/MBC5_Rumble_Strong.svg}}

--- a/src/imgs/src/preproc.py
+++ b/src/imgs/src/preproc.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+from graph_render import gen_graph
+
+if len(sys.argv) == 3 and sys.argv[1] == "supports":
+	sys.exit(sys.argv[2] == "not-supported")
+
+# Copy the book object from standard input to standard output.
+context,book = json.JSONDecoder().decode(sys.stdin.read())
+sys.stdout.write(json.JSONEncoder().encode(book))
+sys.stdout.close() # Ensure that nothing else gets written.
+
+pathlib.Path("./generated").mkdir(exist_ok=True)
+gen_graph("src/imgs/src/MBC5_Rumble_Mild.csv", "Mild Rumble", "./generated/MBC5_Rumble_Mild.svg")
+gen_graph("src/imgs/src/MBC5_Rumble_Strong.csv", "Strong Rumble", "./generated/MBC5_Rumble_Strong.svg")


### PR DESCRIPTION
Supersedes and closes #452
Original OP follows:

---

It may seem a bit convoluted, but it works:

https://user-images.githubusercontent.com/14352721/201120995-a3bf61d5-e9f6-472f-ba4a-b150bfb8c9dd.mp4

Some more stuff is needed to merge this but we should be already at a pretty good point:

- [x] move from pygal to matplotlib #449
- [x] make the output SVG use the CSS variables instead of hardcoded colross
- [ ] update requirements.txt
- [ ] move the call to the plot generation from the `renderer` to the `preproc` step of mdbook, otherwise the output SVG files cannot be inline injected
	- We should consider just calling a python script, instead of having the single calls for every plot like it is now [here](https://github.com/gbdev/pandocs/blob/master/book.toml#L16). @ISSOtm opinions?
- [ ] replace the two img tags with #import in the MBC5 article so the svg is actually injected in the HTML

Fixes #322