### PR TITLE
Improve contrast of bit-descrs borders

### DIFF
--- a/custom/style.css
+++ b/custom/style.css
@@ -178,24 +178,8 @@ mfrac msup :not(:first-child) {
 }
 
 /* Improve contrast on bit-descrs borders */
-.ayu .bit-descrs {
-  --table-border-color: hsl(210, 25%, 30%);
-}
-
-.coal .bit-descrs {
-  --table-border-color: hsl(200, 7%, 30%);
-}
-
-.light .bit-descrs {
-  --table-border-color: hsl(0, 0%, 70%);
-}
-
-.navy .bit-descrs {
-  --table-border-color: hsl(226, 23%, 40%);
-}
-
-.rust .bit-descrs {
-  --table-border-color: hsl(60, 9%, 60%);
+.bit-descrs {
+  --table-border-color: var(--table-header-bg);
 }
 
 p, .table-wrapper {

--- a/custom/style.css
+++ b/custom/style.css
@@ -177,6 +177,27 @@ mfrac msup :not(:first-child) {
     text-align: center;
 }
 
+/* Improve contrast on bit-descrs borders */
+.ayu .bit-descrs {
+  --table-border-color: hsl(210, 25%, 30%);
+}
+
+.coal .bit-descrs {
+  --table-border-color: hsl(200, 7%, 30%);
+}
+
+.light .bit-descrs {
+  --table-border-color: hsl(0, 0%, 70%);
+}
+
+.navy .bit-descrs {
+  --table-border-color: hsl(226, 23%, 40%);
+}
+
+.rust .bit-descrs {
+  --table-border-color: hsl(60, 9%, 60%);
+}
+
 p, .table-wrapper {
   margin-block-start: 1em;
   margin-block-end: 1em;


### PR DESCRIPTION
Proposed solution to improve border contrast for #529
![image](https://github.com/gbdev/pandocs/assets/1981001/9058b20e-b6fd-46b4-89a8-676f54c1daff)
![image](https://github.com/gbdev/pandocs/assets/1981001/65585549-f250-4d9f-a9d0-cf5ac3061351)
![image](https://github.com/gbdev/pandocs/assets/1981001/842e69d0-1d84-45cd-ba44-115ed9a990b9)
![image](https://github.com/gbdev/pandocs/assets/1981001/d3174def-d04a-4e7a-806b-cddd92fb0ca8)
![image](https://github.com/gbdev/pandocs/assets/1981001/a3135c71-45e3-4045-b059-eb326ccbe201)
