### PR TITLE
Accurately reflect which registers are actually available

### DIFF
--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -312,19 +312,19 @@ Name          | Address | DMG0     | DMG / MGB | SGB / SGB2 | CGB / AGB
 [`OBP1`]      | $FF49   | ??[^obp] | ??[^obp]  | ??[^obp]   | ??[^obp]
 [`WY`]        | $FF4A   | $00      | $00       | $00        | $00
 [`WX`]        | $FF4B   | $00      | $00       | $00        | $00
-[`KEY1`]      | $FF4D   | ---      | ---       | ---        | N/A or $7E[^compat]
-[`VBK`]       | $FF4F   | ---      | ---       | ---        | N/A or $FE[^compat]
-[`HDMA1`]     | $FF51   | ---      | ---       | ---        | $FF
-[`HDMA2`]     | $FF52   | ---      | ---       | ---        | $FF
-[`HDMA3`]     | $FF53   | ---      | ---       | ---        | $FF
-[`HDMA4`]     | $FF54   | ---      | ---       | ---        | $FF
-[`HDMA5`]     | $FF55   | ---      | ---       | ---        | $FF
-[`RP`]        | $FF56   | ---      | ---       | ---        | N/A or $3E[^compat]
+[`KEY1`]      | $FF4D   | ---      | ---       | ---        | $7E[^cgb_only]
+[`VBK`]       | $FF4F   | ---      | ---       | ---        | $FE[^cgb_only]
+[`HDMA1`]     | $FF51   | ---      | ---       | ---        | $FF[^cgb_only]
+[`HDMA2`]     | $FF52   | ---      | ---       | ---        | $FF[^cgb_only]
+[`HDMA3`]     | $FF53   | ---      | ---       | ---        | $FF[^cgb_only]
+[`HDMA4`]     | $FF54   | ---      | ---       | ---        | $FF[^cgb_only]
+[`HDMA5`]     | $FF55   | ---      | ---       | ---        | $FF[^cgb_only]
+[`RP`]        | $FF56   | ---      | ---       | ---        | $3E[^cgb_only]
 [`BCPS`]      | $FF68   | ---      | ---       | ---        | ??[^compat]
 [`BCPD`]      | $FF69   | ---      | ---       | ---        | ??[^compat]
 [`OCPS`]      | $FF6A   | ---      | ---       | ---        | ??[^compat]
 [`OCPD`]      | $FF6B   | ---      | ---       | ---        | ??[^compat]
-[`SVBK`]      | $FF70   | ---      | ---       | ---        | N/A or $F8[^compat]
+[`SVBK`]      | $FF70   | ---      | ---       | ---        | $F8[^cgb_only]
 [`IE`]        | $FFFF   | $00      | $00       | $00        | $00
 
 [^unk]:
@@ -342,6 +342,8 @@ Make sure to always set those before displaying objects for the first time.
 
 [^compat]:
 These depend on whether compatibility mode is enabled.
+
+[^cgb_only]: These registers are only available in CGB Mode, and will read \$FF in Non-CGB Mode.
 
 The table above was obtained from Mooneye-GB tests [`acceptance/boot_hwio-dmg0`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_hwio-dmg0.s), [`acceptance/boot_hwio-dmgABCmgb`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_hwio-dmgABCmgb.s), [`acceptance/boot_hwio-S`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_hwio-S.s), and [`misc/boot_hwio-C`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/misc/boot_hwio-C.s), plus some extra testing.
 

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -324,7 +324,7 @@ Name          | Address | DMG0     | DMG / MGB | SGB / SGB2 | CGB / AGB
 [`BCPD`]      | $FF69   | ---      | ---       | ---        | ??[^compat]
 [`OCPS`]      | $FF6A   | ---      | ---       | ---        | ??[^compat]
 [`OCPD`]      | $FF6B   | ---      | ---       | ---        | ??[^compat]
-[`SVBK`]      | $FF70   | ---      | ---       | ---        | $FF
+[`SVBK`]      | $FF70   | ---      | ---       | ---        | N/A or $F8[^compat]
 [`IE`]        | $FFFF   | $00      | $00       | $00        | $00
 
 [^unk]:

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -312,19 +312,19 @@ Name          | Address | DMG0     | DMG / MGB | SGB / SGB2 | CGB / AGB
 [`OBP1`]      | $FF49   | ??[^obp] | ??[^obp]  | ??[^obp]   | ??[^obp]
 [`WY`]        | $FF4A   | $00      | $00       | $00        | $00
 [`WX`]        | $FF4B   | $00      | $00       | $00        | $00
-[`KEY1`]      | $FF4D   | $FF      | $FF       | $FF        | $FF
-[`VBK`]       | $FF4F   | $FF      | $FF       | $FF        | $FF
-[`HDMA1`]     | $FF51   | $FF      | $FF       | $FF        | $FF
-[`HDMA2`]     | $FF52   | $FF      | $FF       | $FF        | $FF
-[`HDMA3`]     | $FF53   | $FF      | $FF       | $FF        | $FF
-[`HDMA4`]     | $FF54   | $FF      | $FF       | $FF        | $FF
-[`HDMA5`]     | $FF55   | $FF      | $FF       | $FF        | $FF
-[`RP`]        | $FF56   | $FF      | $FF       | $FF        | $FF
-[`BCPS`]      | $FF68   | $FF      | $FF       | $FF        | ??[^compat]
-[`BCPD`]      | $FF69   | $FF      | $FF       | $FF        | ??[^compat]
-[`OCPS`]      | $FF6A   | $FF      | $FF       | $FF        | ??[^compat]
-[`OCPD`]      | $FF6B   | $FF      | $FF       | $FF        | ??[^compat]
-[`SVBK`]      | $FF70   | $FF      | $FF       | $FF        | $FF
+[`KEY1`]      | $FF4D   | ---      | ---       | ---        | N/A or $7E[^compat]
+[`VBK`]       | $FF4F   | ---      | ---       | ---        | N/A or $FE[^compat]
+[`HDMA1`]     | $FF51   | ---      | ---       | ---        | $FF
+[`HDMA2`]     | $FF52   | ---      | ---       | ---        | $FF
+[`HDMA3`]     | $FF53   | ---      | ---       | ---        | $FF
+[`HDMA4`]     | $FF54   | ---      | ---       | ---        | $FF
+[`HDMA5`]     | $FF55   | ---      | ---       | ---        | $FF
+[`RP`]        | $FF56   | ---      | ---       | ---        | N/A or $3E[^compat]
+[`BCPS`]      | $FF68   | ---      | ---       | ---        | ??[^compat]
+[`BCPD`]      | $FF69   | ---      | ---       | ---        | ??[^compat]
+[`OCPS`]      | $FF6A   | ---      | ---       | ---        | ??[^compat]
+[`OCPD`]      | $FF6B   | ---      | ---       | ---        | ??[^compat]
+[`SVBK`]      | $FF70   | ---      | ---       | ---        | $FF
 [`IE`]        | $FFFF   | $00      | $00       | $00        | $00
 
 [^unk]:


### PR DESCRIPTION
Trying to deal with #525.

Preview available at https://sonosoos.github.io/pandocs/Power_Up_Sequence.html#hardware-registers

Definitely more work is needed, as I think now these values need a proper re-test now, and also a new column for CGB/AGB in DMG mode, instead of this weird "X or Y" with a footnote thing.

This PR is just to get the ball rolling, I wouldn't merge this as-is. Definitely needs some edits, whether the values are correct or not, as I think there are better ways to display the initial regs.

As for the suggestion in #525, I do think that the triple dashes look good both on-page and in the source file, so I think that's what we should go with instead of `N/A`.

Observations:
- Does it really make sense that P1 would be anything but $CF outside of SGB/SGB2?
- Are OBP0 and OBP1 truly uninitialized? Don't have all the boys to test, but pretty sure it should be always $00, like every other reg.
- Feels like whoever did this test, they've ran the test in DMG mode on CGB/AGB. I think it needs a separate column for that, especially since there should be actual differences between real DMG and DMG mode.
- Shouldn't SC be $7C on CGB/AGB instead of $7F?
- I assume RP would also gated when in DMG mode, it wouldn't make sense for it to be enabled by default, so I'm changing it to what I think should be default ($3E).