### PR TITLE
Correct description of SC clock speed switch

### DIFF
--- a/src/Serial_Data_Transfer_(Link_Cable).md
+++ b/src/Serial_Data_Transfer_(Link_Cable).md
@@ -37,7 +37,7 @@ incoming bit is shifted in from the other side:
 }}
 
 - **Transfer enable** (*Read/Write*): If `1`, a transfer is either requested or in progress.
-- **Clock speed** \[*CGB Mode only*\] (*Read/Write*): If set to `1`, the internal clock's speed is doubled.
+- **Clock speed** \[*CGB Mode only*\] (*Read/Write*): If set to `1`, enable high speed serial clock (~256 kHz in single-speed mode)
 - **Clock select** (*Read/Write*): `0` = External clock ("slave"), `1` = Internal clock ("master").
 
 The master Game Boy will load up a data byte in SB and then set


### PR DESCRIPTION
This is a pretty straightforward error correction. It didn't seem worth making an issue for it first, hopefully that's OK.

The change is to the description of the serial clock speed selector (bit 1, register SC).
The erroneous description stated that the optional higher speed was a doubling in frequency, but the actual behaviour is switching between the standard 8 kHz and the ridiculous 256 kHz (*32ing it!*).
The new description is also now in accord with the table of clock frequencies a little bit further down, under the **Internal Clock** heading.

(The serial clock frequency is *also* doubled by the system double-speed mode, which may be where some confusion came from)

<!-- Alternative solution: new implementation of the double function: `double(x) = x 2⁵` -->