### PR TITLE
Fix some typos & inconsistencies in Licensees

### DIFF
--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -79,10 +79,10 @@ Code | Publisher
 `08` | [Capcom](https://en.wikipedia.org/wiki/Capcom)
 `13` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 `18` | [Hudson Soft](https://en.wikipedia.org/wiki/Hudson_Soft)
-`19` | B-AI
-`20` | KSS
-`22` | Pow
-`24` | PCM Complete
+`19` | [B-AI](https://www.giantbomb.com/b-ai/3010-8160)
+`20` | [KSS](https://en.wikipedia.org/wiki/KSS_(company))
+`22` | [Planning Office WADA](https://www.mobygames.com/company/15869/planning-office-wada)
+`24` | [PCM Complete](https://www.mobygames.com/company/9489/pcm-complete)
 `25` | San-X
 `28` | Kemco Japan
 `29` | seta
@@ -136,6 +136,7 @@ Code | Publisher
 `99` | Pack in soft
 `9H` | Bottom Up
 `A4` | [Konami](https://en.wikipedia.org/wiki/Konami) (Yu-Gi-Oh!)
+`DK` | [Kodansha](https://en.wikipedia.org/wiki/Kodansha)
 
 ## 0146 — SGB flag
 
@@ -265,7 +266,7 @@ HEX   | Licensee
 1A    | [Yanoman](https://en.wikipedia.org/wiki/Category:Yanoman_games)
 1D    | [Japan Clary](https://www.mobygames.com/company/7639/japan-clary-business/)
 1F    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
-24    | PCM Complete       
+24    | [PCM Complete](https://www.mobygames.com/company/9489/pcm-complete)
 25    | San-X
 28    | Kotobuki Systems   
 29    | Seta               

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -120,7 +120,7 @@ Code | Publisher
 `71` | Interplay
 `72` | Broderbund
 `73` | Sculptured Software
-`75` | SCi (Sales Curve Interactive)
+`75` | The Sales Curve Limited
 `78` | THQ
 `79` | Accolade
 `80` | Misawa Entertainment
@@ -311,7 +311,7 @@ HEX   | Licensee
 71    | Interplay
 72    | Broderbund         
 73    | Sculptured Software   
-75    | SCi (Sales Curve Interactive)
+75    | The Sales Curve Limited
 78    | THQ             
 79    | Accolade           
 7A    | Triffix Entertainment

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -91,15 +91,15 @@ Code | Publisher
 `32` | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 `33` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)/[Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 `34` | [Konami](https://en.wikipedia.org/wiki/Konami)
-`35` | Hector
-`37` | Taito
+`35` | [HectorSoft](https://www.mobygames.com/company/12239/hectorsoft)
+`37` | [Taito](https://en.wikipedia.org/wiki/Taito)
 `38` | [Hudson Soft](https://en.wikipedia.org/wiki/Hudson_Soft)
 `39` | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 `41` | [Ubi Soft](https://en.wikipedia.org/wiki/Ubisoft)[^ubisoft]
 `42` | [Atlus](https://en.wikipedia.org/wiki/Atlus)
 `44` | [Malibu Interactive](https://en.wikipedia.org/wiki/Malibu_Comics)
 `46` | [Angel](https://www.mobygames.com/company/5083/angel)
-`47` | Bullet-Proof Software
+`47` | [Bullet-Proof Software](https://en.wikipedia.org/wiki/Blue_Planet_Software)[^blueplanet]
 `49` | Irem
 `50` | Absolute
 `51` | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
@@ -111,7 +111,7 @@ Code | Publisher
 `57` | Matchbox
 `58` | Mattel
 `59` | Milton Bradley
-`60` | Titus
+`60` | [Titus Interactive](https://en.wikipedia.org/wiki/Titus_Interactive)
 `61` | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 `64` | [Lucasfilm Games](https://en.wikipedia.org/wiki/Lucasfilm_Games)[^lucasfilm]
 `67` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)
@@ -119,7 +119,7 @@ Code | Publisher
 `70` | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 `71` | Interplay
 `72` | Broderbund
-`73` | Sculptured Software
+`73` | [Sculptured Software](https://en.wikipedia.org/wiki/Iguana_Entertainment)[^sculptured]
 `75` | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
 `78` | THQ
 `79` | Accolade
@@ -274,7 +274,7 @@ HEX   | Licensee
 32    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 33    | Indicates that the [New licensee code](<#0144–0145 — New licensee code>) should be used instead.
 34    | [Konami](https://en.wikipedia.org/wiki/Konami)
-35    | HectorSoft            
+35    | [HectorSoft](https://www.mobygames.com/company/12239/hectorsoft)            
 38    | [Capcom](https://en.wikipedia.org/wiki/Capcom)
 39    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 3C    | .Entertainment i   
@@ -286,31 +286,31 @@ HEX   | Licensee
 47    | Spectrum Holoby    
 49    | Irem
 4A    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
-4D    | Malibu             
+4D    | [Malibu Interactive](https://en.wikipedia.org/wiki/Malibu_Comics)
 4F    | U.S. Gold
 50    | Absolute           
 51    | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 52    | [Activision](https://en.wikipedia.org/wiki/Activision)
 53    | American Sammy     
-54    | GameTek           
+54    | [GameTek](https://en.wikipedia.org/wiki/GameTek)
 55    | Park Place
 56    | LJN                
 57    | Matchbox           
 59    | Milton Bradley
-5A    | Mindscape          
-5B    | Romstar            
-5C    | Naxat Soft
-5D    | Tradewest          
-60    | Titus              
+5A    | [Mindscape](https://en.wikipedia.org/wiki/Mindscape_(company))
+5B    | [Romstar](https://en.wikipedia.org/wiki/Romstar)
+5C    | [Naxat Soft](https://en.wikipedia.org/wiki/Kaga_Create)[^kaga]
+5D    | [Tradewest](https://en.wikipedia.org/wiki/Tradewest)
+60    | [Titus Interactive](https://en.wikipedia.org/wiki/Titus_Interactive)
 61    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 67    | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)
 69    | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
-6E    | Elite Systems
+6E    | [Elite Systems](https://en.wikipedia.org/wiki/Elite_Systems)
 6F    | Electro Brain      
 70    | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 71    | Interplay
 72    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
-73    | Sculptured Software   
+73    | [Sculptured Software](https://en.wikipedia.org/wiki/Iguana_Entertainment)[^sculptured]
 75    | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
 78    | THQ             
 79    | Accolade           
@@ -320,7 +320,7 @@ HEX   | Licensee
 80    | Misawa Entertainment
 83    | Lozc               
 86    | Tokuma Shoten Intermedia   
-8B    | Bullet-Proof Software
+8B    | [Bullet-Proof Software](https://en.wikipedia.org/wiki/Blue_Planet_Software)[^blueplanet]
 8C    | Vic Tokai          
 8E    | Ape                
 8F    | I'Max
@@ -371,12 +371,12 @@ CC    | Use Corporation
 CD    | Meldac
 CE    | [Pony Canyon](https://en.wikipedia.org/wiki/Pony_Canyon)
 CF    | [Angel](https://www.mobygames.com/company/5083/angel)
-D0    | Taito
+D0    | [Taito](https://en.wikipedia.org/wiki/Taito)
 D1    | Sofel              
 D2    | Quest              
 D3    | Sigma Enterprises
 D4    | ASK Kodansha Co.       
-D6    | Naxat Soft         
+D6    | [Naxat Soft](https://en.wikipedia.org/wiki/Kaga_Create)[^kaga]
 D7    | Copya System
 D9    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 DA    | Tomy               
@@ -402,13 +402,19 @@ FF    | LJN
 
 [^ubisoft]: Later known as [Ubisoft](https://en.wikipedia.org/wiki/Ubisoft).
 
+[^blueplanet]: Later succeeded by [Blue Planet Software](https://en.wikipedia.org/wiki/Blue_Planet_Software), then acquired by [The Tetris Company](https://en.wikipedia.org/wiki/The_Tetris_Company) in 2020.
+
 [^virgin]: Later known as [Virgin Mastertronic Ltd., then Virgin Interactive Entertainment, then Avalon Interactive Group, Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment).
 
 [^lucasfilm]: Later known as [LucasArts](https://en.wikipedia.org/wiki/Lucasfilm_Games) between 1990-2021.
 
 [^atari]: Later known as [Atari SA](https://en.wikipedia.org/wiki/Atari_SA).
 
-[^sci]: Later known as [SCi (Sales Curve Interactive), then SCi Entertainment Group plc, then Eidos](https://en.wikipedia.org/wiki/SCi_Games), then accquired by [Square Enix](https://en.wikipedia.org/wiki/Square_Enix) in 2009.
+[^sculptured]: Later accquired by [Iguana Entertainment](https://en.wikipedia.org/wiki/Iguana_Entertainment) in 1995. Parent studio owned by [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment).
+
+[^sci]: Later known as [SCi (Sales Curve Interactive), then SCi Entertainment Group plc, then Eidos](https://en.wikipedia.org/wiki/SCi_Games), then acquired by [Square Enix](https://en.wikipedia.org/wiki/Square_Enix) in 2009.
+
+[^kaga]: Later known as [Kaga Create](https://en.wikipedia.org/wiki/Kaga_Create).
 
 ## 014C — Mask ROM version number
 

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -77,13 +77,13 @@ Code | Publisher
 `00` | None
 `01` | Nintendo R&D1
 `08` | Capcom
-`13` | Electronic Arts
+`13` | EA (Electronic Arts)
 `18` | Hudson Soft
-`19` | b-ai
-`20` | kss
-`22` | pow
+`19` | B-AI
+`20` | KSS
+`22` | Pow
 `24` | PCM Complete
-`25` | san-x
+`25` | San-X
 `28` | Kemco Japan
 `29` | seta
 `30` | Viacom
@@ -93,44 +93,44 @@ Code | Publisher
 `34` | Konami
 `35` | Hector
 `37` | Taito
-`38` | Hudson
+`38` | Hudson Soft
 `39` | Banpresto
 `41` | Ubi Soft
 `42` | Atlus
 `44` | Malibu
-`46` | angel
-`47` | Bullet-Proof
-`49` | irem
+`46` | Angel
+`47` | Bullet-Proof Software
+`49` | Irem
 `50` | Absolute
 `51` | Acclaim
 `52` | Activision
-`53` | American sammy
+`53` | American Sammy
 `54` | Konami
-`55` | Hi tech entertainment
+`55` | Hi Tech Entertainment
 `56` | LJN
 `57` | Matchbox
 `58` | Mattel
 `59` | Milton Bradley
 `60` | Titus
-`61` | Virgin
+`61` | Virgin Interactive
 `64` | LucasArts
 `67` | Ocean
-`69` | Electronic Arts
+`69` | EA (Electronic Arts)
 `70` | Infogrames
 `71` | Interplay
 `72` | Broderbund
-`73` | sculptured
-`75` | sci
+`73` | Sculptured Software
+`75` | SCi (Sales Curve Interactive)
 `78` | THQ
 `79` | Accolade
-`80` | misawa
+`80` | Misawa Entertainment
 `83` | lozc
 `86` | Tokuma Shoten Intermedia
 `87` | Tsukuda Original
 `91` | Chunsoft
 `92` | Video system
 `93` | Ocean/Acclaim
-`95` | Varie
+`95` | Varie Corporation
 `96` | Yonezawa/s'pal
 `97` | Kaneko
 `99` | Pack in soft
@@ -260,7 +260,7 @@ HEX   | Licensee
 0B    | Coconuts Japan
 0C    | Elite Systems      
 13    | EA (Electronic Arts)    
-18    | Hudsonsoft
+18    | Hudson Soft
 19    | ITC Entertainment  
 1A    | Yanoman            
 1D    | Japan Clary
@@ -310,9 +310,9 @@ HEX   | Licensee
 70    | Infogrames         
 71    | Interplay
 72    | Broderbund         
-73    | Sculptered Soft   
-75    | The Sales Curve
-78    | t.hq               
+73    | Sculptured Software   
+75    | SCi (Sales Curve Interactive)
+78    | THQ             
 79    | Accolade           
 7A    | Triffix Entertainment
 7C    | Microprose         
@@ -346,8 +346,8 @@ AA    | Broderbund
 AC    | Toei Animation    
 AD    | Toho
 AF    | Namco             
-B0    | acclaim           
-B1    | ASCII or Nexsoft
+B0    | Acclaim           
+B1    | ASCII Corportation or Nexsoft
 B2    | Bandai             
 B4    | Square Enix               
 B6    | HAL Laboratory
@@ -369,7 +369,7 @@ CA    | Ultra
 CB    | Vap                
 CC    | Use Corporation               
 CD    | Meldac
-CE    | .Pony Canyon or    
+CE    | Pony Canyon    
 CF    | Angel              
 D0    | Taito
 D1    | Sofel              
@@ -387,7 +387,7 @@ DF    | Altron
 E0    | Jaleco             
 E1    | Towa Chiki          
 E2    | Yutaka
-E3    | Varie              
+E3    | Varie Corporation  
 E5    | Epcoh              
 E7    | Athena
 E8    | Asmik ACE Entertainment             

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -136,6 +136,7 @@ Code | Publisher
 `99` | [Pack-In-Video](https://en.wikipedia.org/wiki/Pack-In-Video)
 `9H` | Bottom Up
 `A4` | [Konami](https://en.wikipedia.org/wiki/Konami) (Yu-Gi-Oh!)
+`BL` | [MTO](https://en.wikipedia.org/wiki/MTO_(video_game_company))
 `DK` | [Kodansha](https://en.wikipedia.org/wiki/Kodansha)
 
 ## 0146 — SGB flag

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -108,16 +108,16 @@ Code | Publisher
 `54` | [Konami](https://en.wikipedia.org/wiki/Konami)
 `55` | [Hi Tech Expressions](https://en.wikipedia.org/wiki/Hi_Tech_Expressions)
 `56` | [LJN](https://en.wikipedia.org/wiki/LJN)
-`57` | Matchbox
-`58` | Mattel
-`59` | Milton Bradley
+`57` | [Matchbox](https://en.wikipedia.org/wiki/Matchbox_(brand))
+`58` | [Mattel](https://en.wikipedia.org/wiki/Mattel)
+`59` | [Milton Bradley Company](https://en.wikipedia.org/wiki/Milton_Bradley_Company)
 `60` | [Titus Interactive](https://en.wikipedia.org/wiki/Titus_Interactive)
 `61` | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 `64` | [Lucasfilm Games](https://en.wikipedia.org/wiki/Lucasfilm_Games)[^lucasfilm]
 `67` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)
 `69` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 `70` | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
-`71` | Interplay
+`71` | [Interplay Entertainment](https://en.wikipedia.org/wiki/Interplay_Entertainment)
 `72` | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
 `73` | [Sculptured Software](https://en.wikipedia.org/wiki/Iguana_Entertainment)[^sculptured]
 `75` | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
@@ -128,7 +128,7 @@ Code | Publisher
 `86` | [Tokuma Shoten](https://en.wikipedia.org/wiki/Tokuma_Shoten)
 `87` | Tsukuda Original
 `91` | [Chunsoft Co.](https://en.wikipedia.org/wiki/Spike_Chunsoft)[^spike]
-`92` | Video system
+`92` | Video System
 `93` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)/[Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 `95` | [Varie](https://en.wikipedia.org/wiki/Varie)
 `96` | Yonezawa/s'pal
@@ -296,8 +296,8 @@ HEX   | Licensee
 54    | [GameTek](https://en.wikipedia.org/wiki/GameTek)
 55    | Park Place
 56    | [LJN](https://en.wikipedia.org/wiki/LJN)
-57    | Matchbox           
-59    | Milton Bradley
+57    | [Matchbox](https://en.wikipedia.org/wiki/Matchbox_(brand))
+59    | [Milton Bradley Company](https://en.wikipedia.org/wiki/Milton_Bradley_Company)
 5A    | [Mindscape](https://en.wikipedia.org/wiki/Mindscape_(company))
 5B    | [Romstar](https://en.wikipedia.org/wiki/Romstar)
 5C    | [Naxat Soft](https://en.wikipedia.org/wiki/Kaga_Create)[^kaga]
@@ -309,7 +309,7 @@ HEX   | Licensee
 6E    | [Elite Systems](https://en.wikipedia.org/wiki/Elite_Systems)
 6F    | Electro Brain      
 70    | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
-71    | Interplay
+71    | [Interplay Entertainment](https://en.wikipedia.org/wiki/Interplay_Entertainment)
 72    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
 73    | [Sculptured Software](https://en.wikipedia.org/wiki/Iguana_Entertainment)[^sculptured]
 75    | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -76,9 +76,9 @@ Code | Publisher
 -----|-------------------------
 `00` | None
 `01` | [Nintendo Research & Development 1](https://en.wikipedia.org/wiki/Nintendo_Research_%26_Development_1)
-`08` | Capcom
+`08` | [Capcom](https://en.wikipedia.org/wiki/Capcom)
 `13` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
-`18` | Hudson Soft
+`18` | [Hudson Soft](https://en.wikipedia.org/wiki/Hudson_Soft)
 `19` | B-AI
 `20` | KSS
 `22` | Pow
@@ -88,15 +88,15 @@ Code | Publisher
 `29` | seta
 `30` | Viacom
 `31` | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
-`32` | Bandai
+`32` | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 `33` | Ocean/Acclaim
-`34` | Konami
+`34` | [Konami](https://en.wikipedia.org/wiki/Konami)
 `35` | Hector
 `37` | Taito
-`38` | Hudson Soft
+`38` | [Hudson Soft](https://en.wikipedia.org/wiki/Hudson_Soft)
 `39` | Banpresto
-`41` | Ubi Soft
-`42` | Atlus
+`41` | [Ubi Soft](https://en.wikipedia.org/wiki/Ubisoft)[^ubisoft]
+`42` | [Atlus](https://en.wikipedia.org/wiki/Atlus)
 `44` | Malibu
 `46` | Angel
 `47` | Bullet-Proof Software
@@ -105,7 +105,7 @@ Code | Publisher
 `51` | Acclaim
 `52` | Activision
 `53` | American Sammy
-`54` | Konami
+`54` | [Konami](https://en.wikipedia.org/wiki/Konami)
 `55` | Hi Tech Entertainment
 `56` | LJN
 `57` | Matchbox
@@ -116,7 +116,7 @@ Code | Publisher
 `64` | LucasArts
 `67` | Ocean
 `69` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
-`70` | Infogrames
+`70` | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 `71` | Interplay
 `72` | Broderbund
 `73` | Sculptured Software
@@ -135,7 +135,7 @@ Code | Publisher
 `97` | Kaneko
 `99` | Pack in soft
 `9H` | Bottom Up
-`A4` | Konami (Yu-Gi-Oh!)
+`A4` | [Konami](https://en.wikipedia.org/wiki/Konami) (Yu-Gi-Oh!)
 
 ## 0146 — SGB flag
 
@@ -269,18 +269,18 @@ HEX   | Licensee
 25    | San-X
 28    | Kotobuki Systems   
 29    | Seta               
-30    | Infogrames
+30    | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 31    | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
-32    | Bandai             
+32    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 33    | Indicates that the [New licensee code](<#0144–0145 — New licensee code>) should be used instead.
-34    | Konami             
+34    | [Konami](https://en.wikipedia.org/wiki/Konami)
 35    | HectorSoft            
-38    | Capcom
+38    | [Capcom](https://en.wikipedia.org/wiki/Capcom)
 39    | Banpresto          
 3C    | .Entertainment i   
 3E    | Gremlin
-41    | Ubisoft           
-42    | Atlus              
+41    | [Ubi Soft](https://en.wikipedia.org/wiki/Ubisoft)[^ubisoft]
+42    | [Atlus](https://en.wikipedia.org/wiki/Atlus)
 44    | Malibu
 46    | Angel              
 47    | Spectrum Holoby    
@@ -307,7 +307,7 @@ HEX   | Licensee
 69    | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 6E    | Elite Systems
 6F    | Electro Brain      
-70    | Infogrames         
+70    | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 71    | Interplay
 72    | Broderbund         
 73    | Sculptured Software   
@@ -337,8 +337,8 @@ HEX   | Licensee
 9D    | Banpresto          
 9F    | Nova
 A1    | Hori Electric      
-A2    | Bandai             
-A4    | Konami
+A2    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
+A4    | [Konami](https://en.wikipedia.org/wiki/Konami)
 A6    | Kawada             
 A7    | Takara             
 A9    | Technos Japan
@@ -400,9 +400,13 @@ F0    | A Wave
 F3    | Extreme Entertainment  
 FF    | LJN
 
-[^sci]: Later known as [SCi (Sales Curve Interactive), then SCi Entertainment Group plc, then Eidos](https://en.wikipedia.org/wiki/SCi_Games), then accquired by [Square Enix](https://en.wikipedia.org/wiki/Square_Enix) in 2009.
+[^ubisoft]: Later known as [Ubisoft](https://en.wikipedia.org/wiki/Ubisoft).
 
 [^virgin]: Later known as [Virgin Mastertronic Ltd., then Virgin Interactive Entertainment, then Avalon Interactive Group, Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment).
+
+[^atari]: Later known as [Atari SA](https://en.wikipedia.org/wiki/Atari_SA).
+
+[^sci]: Later known as [SCi (Sales Curve Interactive), then SCi Entertainment Group plc, then Eidos](https://en.wikipedia.org/wiki/SCi_Games), then accquired by [Square Enix](https://en.wikipedia.org/wiki/Square_Enix) in 2009.
 
 ## 014C — Mask ROM version number
 

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -347,7 +347,7 @@ AC    | Toei Animation
 AD    | Toho
 AF    | Namco             
 B0    | Acclaim           
-B1    | ASCII Corportation or Nexsoft
+B1    | ASCII Corporation or Nexsoft
 B2    | Bandai             
 B4    | Square Enix               
 B6    | HAL Laboratory

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -100,14 +100,14 @@ Code | Publisher
 `44` | [Malibu Interactive](https://en.wikipedia.org/wiki/Malibu_Comics)
 `46` | [Angel](https://www.mobygames.com/company/5083/angel)
 `47` | [Bullet-Proof Software](https://en.wikipedia.org/wiki/Blue_Planet_Software)[^blueplanet]
-`49` | Irem
+`49` | [Irem](https://en.wikipedia.org/wiki/Irem)
 `50` | Absolute
 `51` | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 `52` | [Activision](https://en.wikipedia.org/wiki/Activision)
 `53` | [Sammy USA Corporation](https://en.wikipedia.org/wiki/Sammy_Corporation)
 `54` | [Konami](https://en.wikipedia.org/wiki/Konami)
 `55` | [Hi Tech Expressions](https://en.wikipedia.org/wiki/Hi_Tech_Expressions)
-`56` | LJN
+`56` | [LJN](https://en.wikipedia.org/wiki/LJN)
 `57` | Matchbox
 `58` | Mattel
 `59` | Milton Bradley
@@ -118,22 +118,22 @@ Code | Publisher
 `69` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 `70` | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 `71` | Interplay
-`72` | Broderbund
+`72` | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
 `73` | [Sculptured Software](https://en.wikipedia.org/wiki/Iguana_Entertainment)[^sculptured]
 `75` | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
-`78` | THQ
+`78` | [THQ](https://en.wikipedia.org/wiki/THQ)
 `79` | Accolade
-`80` | Misawa Entertainment
+`80` | [Misawa Entertainment](https://www.mobygames.com/company/8225/misawa-entertainment-coltd)
 `83` | lozc
-`86` | Tokuma Shoten Intermedia
+`86` | [Tokuma Shoten](https://en.wikipedia.org/wiki/Tokuma_Shoten)
 `87` | Tsukuda Original
-`91` | Chunsoft
+`91` | [Chunsoft Co.](https://en.wikipedia.org/wiki/Spike_Chunsoft)[^spike]
 `92` | Video system
 `93` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)/[Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 `95` | [Varie](https://en.wikipedia.org/wiki/Varie)
 `96` | Yonezawa/s'pal
-`97` | Kaneko
-`99` | Pack in soft
+`97` | [Kaneko](https://en.wikipedia.org/wiki/Kaneko)
+`99` | [Pack-In-Video](https://en.wikipedia.org/wiki/Pack-In-Video)
 `9H` | Bottom Up
 `A4` | [Konami](https://en.wikipedia.org/wiki/Konami) (Yu-Gi-Oh!)
 `DK` | [Kodansha](https://en.wikipedia.org/wiki/Kodansha)
@@ -253,7 +253,7 @@ Here is a list of known Old licensee codes ([source](https://raw.githubuserconte
 
 HEX   | Licensee
 ------|------------
-00    | None               
+00    | None
 01    | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
 08    | [Capcom](https://en.wikipedia.org/wiki/Capcom)
 09    | [HOT-B](https://en.wikipedia.org/wiki/Category:Hot_B_games)
@@ -285,7 +285,7 @@ HEX   | Licensee
 44    | [Malibu Interactive](https://en.wikipedia.org/wiki/Malibu_Comics)
 46    | [Angel](https://www.mobygames.com/company/5083/angel)
 47    | Spectrum Holoby    
-49    | Irem
+49    | [Irem](https://en.wikipedia.org/wiki/Irem)
 4A    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 4D    | [Malibu Interactive](https://en.wikipedia.org/wiki/Malibu_Comics)
 4F    | U.S. Gold
@@ -295,7 +295,7 @@ HEX   | Licensee
 53    | [Sammy USA Corporation](https://en.wikipedia.org/wiki/Sammy_Corporation)
 54    | [GameTek](https://en.wikipedia.org/wiki/GameTek)
 55    | Park Place
-56    | LJN                
+56    | [LJN](https://en.wikipedia.org/wiki/LJN)
 57    | Matchbox           
 59    | Milton Bradley
 5A    | [Mindscape](https://en.wikipedia.org/wiki/Mindscape_(company))
@@ -313,28 +313,28 @@ HEX   | Licensee
 72    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
 73    | [Sculptured Software](https://en.wikipedia.org/wiki/Iguana_Entertainment)[^sculptured]
 75    | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
-78    | THQ             
+78    | [THQ](https://en.wikipedia.org/wiki/THQ)
 79    | Accolade           
-7A    | Triffix Entertainment
+7A    | [Triffix Entertainment](https://www.mobygames.com/company/4307/triffix-entertainment-inc)
 7C    | Microprose         
-7F    | Kemco              
-80    | Misawa Entertainment
+7F    | [Kemco](https://en.wikipedia.org/wiki/Kemco)
+80    | [Misawa Entertainment](https://www.mobygames.com/company/8225/misawa-entertainment-coltd)
 83    | Lozc               
-86    | Tokuma Shoten Intermedia   
+86    | [Tokuma Shoten](https://en.wikipedia.org/wiki/Tokuma_Shoten)   
 8B    | [Bullet-Proof Software](https://en.wikipedia.org/wiki/Blue_Planet_Software)[^blueplanet]
 8C    | Vic Tokai          
 8E    | Ape                
 8F    | I'Max
-91    | Chunsoft Co.         
+91    | [Chunsoft Co.](https://en.wikipedia.org/wiki/Spike_Chunsoft)[^spike]
 92    | Video System       
-93    | Tsubaraya Productions Co.
-95    | Varie Corporation              
+93    | [Tsubaraya Productions](https://en.wikipedia.org/wiki/Tsuburaya_Productions)
+95    | [Varie](https://en.wikipedia.org/wiki/Varie)
 96    | Yonezawa/S'Pal     
-97    | Kaneko
+97    | [Kemco](https://en.wikipedia.org/wiki/Kemco)
 99    | Arc                
 9A    | Nihon Bussan       
 9B    | Tecmo
-9C    | Imagineer          
+9C    | [Imagineer](https://en.wikipedia.org/wiki/Imagineer_(Japanese_company))
 9D    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 9F    | Nova
 A1    | Hori Electric      
@@ -351,17 +351,17 @@ B0    | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainm
 B1    | ASCII Corporation or Nexsoft
 B2    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 B4    | [Square Enix](https://en.wikipedia.org/wiki/Square_Enix)
-B6    | HAL Laboratory
+B6    | [HAL Laboratory](https://en.wikipedia.org/wiki/HAL_Laboratory)
 B7    | SNK                
 B9    | [Pony Canyon](https://en.wikipedia.org/wiki/Pony_Canyon)
-BA    | Culture Brain
+BA    | [Culture Brain](https://en.wikipedia.org/wiki/Culture_Brain)
 BB    | Sunsoft            
 BD    | Sony Imagesoft    
 BF    | [Sammy Corporation](https://en.wikipedia.org/wiki/Sammy_Corporation)
 C0    | [Taito](https://en.wikipedia.org/wiki/Taito)
 C2    | Kemco              
-C3    | Squaresoft
-C4    | Tokuma Shoten Intermedia   
+C3    | [Square](https://en.wikipedia.org/wiki/Square_(video_game_company))
+C4    | [Tokuma Shoten](https://en.wikipedia.org/wiki/Tokuma_Shoten)
 C5    | Data East          
 C6    | Tonkinhouse
 C8    | Koei               
@@ -375,13 +375,13 @@ CF    | [Angel](https://www.mobygames.com/company/5083/angel)
 D0    | [Taito](https://en.wikipedia.org/wiki/Taito)
 D1    | Sofel              
 D2    | Quest              
-D3    | Sigma Enterprises
+D3    | [Sigma Enterprises](https://www.mobygames.com/company/5001/sigma-enterprises-inc)
 D4    | ASK Kodansha Co.       
 D6    | [Naxat Soft](https://en.wikipedia.org/wiki/Kaga_Create)[^kaga]
 D7    | Copya System
 D9    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 DA    | Tomy               
-DB    | LJN
+DB    | [LJN](https://en.wikipedia.org/wiki/LJN)
 DD    | NCS                
 DE    | Human              
 DF    | Altron
@@ -398,8 +398,8 @@ EB    | [Atlus](https://en.wikipedia.org/wiki/Atlus)
 EC    | Epic/Sony Records  
 EE    | IGS
 F0    | A Wave         
-F3    | Extreme Entertainment  
-FF    | LJN
+F3    | [Extreme Entertainment](https://www.mobygames.com/company/4221/extreme-entertainment-group-inc)
+FF    | [LJN](https://en.wikipedia.org/wiki/LJN)
 
 [^ubisoft]: Later known as [Ubisoft](https://en.wikipedia.org/wiki/Ubisoft).
 
@@ -414,6 +414,8 @@ FF    | LJN
 [^sculptured]: Later accquired by [Iguana Entertainment](https://en.wikipedia.org/wiki/Iguana_Entertainment) in 1995. Parent studio owned by [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment).
 
 [^sci]: Later known as [SCi (Sales Curve Interactive), then SCi Entertainment Group plc, then Eidos](https://en.wikipedia.org/wiki/SCi_Games), then acquired by [Square Enix](https://en.wikipedia.org/wiki/Square_Enix) in 2009.
+
+[^spike]: Later known as [Spike Chunsoft Co., Ltd.](https://en.wikipedia.org/wiki/Spike_Chunsoft).
 
 [^kaga]: Later known as [Kaga Create](https://en.wikipedia.org/wiki/Kaga_Create).
 

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -84,9 +84,9 @@ Code | Publisher
 `22` | [Planning Office WADA](https://www.mobygames.com/company/15869/planning-office-wada)
 `24` | [PCM Complete](https://www.mobygames.com/company/9489/pcm-complete)
 `25` | San-X
-`28` | Kemco Japan
-`29` | seta
-`30` | Viacom
+`28` | [Kemco](https://en.wikipedia.org/wiki/Kemco)
+`29` | [SETA Corporation](https://en.wikipedia.org/wiki/SETA_Corporation)
+`30` | [Viacom](https://en.wikipedia.org/wiki/Viacom_(1952%E2%80%932005))
 `31` | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
 `32` | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 `33` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)/[Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
@@ -104,9 +104,9 @@ Code | Publisher
 `50` | Absolute
 `51` | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 `52` | [Activision](https://en.wikipedia.org/wiki/Activision)
-`53` | American Sammy
+`53` | [Sammy USA Corporation](https://en.wikipedia.org/wiki/Sammy_Corporation)
 `54` | [Konami](https://en.wikipedia.org/wiki/Konami)
-`55` | Hi Tech Entertainment
+`55` | [Hi Tech Expressions](https://en.wikipedia.org/wiki/Hi_Tech_Expressions)
 `56` | LJN
 `57` | Matchbox
 `58` | Mattel
@@ -268,14 +268,14 @@ HEX   | Licensee
 1F    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 24    | [PCM Complete](https://www.mobygames.com/company/9489/pcm-complete)
 25    | San-X
-28    | Kotobuki Systems   
-29    | Seta               
+28    | [Kemco](https://en.wikipedia.org/wiki/Kemco)
+29    | [SETA Corporation](https://en.wikipedia.org/wiki/SETA_Corporation)
 30    | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 31    | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
 32    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 33    | Indicates that the [New licensee code](<#0144–0145 — New licensee code>) should be used instead.
 34    | [Konami](https://en.wikipedia.org/wiki/Konami)
-35    | [HectorSoft](https://www.mobygames.com/company/12239/hectorsoft)            
+35    | [HectorSoft](https://www.mobygames.com/company/12239/hectorsoft)
 38    | [Capcom](https://en.wikipedia.org/wiki/Capcom)
 39    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 3C    | .Entertainment i   
@@ -292,7 +292,7 @@ HEX   | Licensee
 50    | Absolute           
 51    | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 52    | [Activision](https://en.wikipedia.org/wiki/Activision)
-53    | American Sammy     
+53    | [Sammy USA Corporation](https://en.wikipedia.org/wiki/Sammy_Corporation)
 54    | [GameTek](https://en.wikipedia.org/wiki/GameTek)
 55    | Park Place
 56    | LJN                
@@ -343,7 +343,7 @@ A4    | [Konami](https://en.wikipedia.org/wiki/Konami)
 A6    | Kawada             
 A7    | Takara             
 A9    | Technos Japan
-AA    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)         
+AA    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
 AC    | Toei Animation    
 AD    | Toho
 AF    | Namco             
@@ -357,8 +357,8 @@ B9    | [Pony Canyon](https://en.wikipedia.org/wiki/Pony_Canyon)
 BA    | Culture Brain
 BB    | Sunsoft            
 BD    | Sony Imagesoft    
-BF    | Sammy
-C0    | Taito             
+BF    | [Sammy Corporation](https://en.wikipedia.org/wiki/Sammy_Corporation)
+C0    | [Taito](https://en.wikipedia.org/wiki/Taito)
 C2    | Kemco              
 C3    | Squaresoft
 C4    | Tokuma Shoten Intermedia   
@@ -391,7 +391,7 @@ E2    | Yutaka
 E3    | [Varie](https://en.wikipedia.org/wiki/Varie)
 E5    | Epcoh              
 E7    | Athena
-E8    | Asmik ACE Entertainment             
+E8    | [Asmik Ace Entertainment](https://en.wikipedia.org/wiki/Asmik_Ace)
 E9    | Natsume            
 EA    | King Records
 EB    | [Atlus](https://en.wikipedia.org/wiki/Atlus)

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -89,7 +89,7 @@ Code | Publisher
 `30` | Viacom
 `31` | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
 `32` | [Bandai](https://en.wikipedia.org/wiki/Bandai)
-`33` | Ocean/Acclaim
+`33` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)/[Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 `34` | [Konami](https://en.wikipedia.org/wiki/Konami)
 `35` | Hector
 `37` | Taito
@@ -97,13 +97,13 @@ Code | Publisher
 `39` | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 `41` | [Ubi Soft](https://en.wikipedia.org/wiki/Ubisoft)[^ubisoft]
 `42` | [Atlus](https://en.wikipedia.org/wiki/Atlus)
-`44` | Malibu
-`46` | Angel
+`44` | [Malibu Interactive](https://en.wikipedia.org/wiki/Malibu_Comics)
+`46` | [Angel](https://www.mobygames.com/company/5083/angel)
 `47` | Bullet-Proof Software
 `49` | Irem
 `50` | Absolute
-`51` | Acclaim
-`52` | Activision
+`51` | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
+`52` | [Activision](https://en.wikipedia.org/wiki/Activision)
 `53` | American Sammy
 `54` | [Konami](https://en.wikipedia.org/wiki/Konami)
 `55` | Hi Tech Entertainment
@@ -114,7 +114,7 @@ Code | Publisher
 `60` | Titus
 `61` | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 `64` | [Lucasfilm Games](https://en.wikipedia.org/wiki/Lucasfilm_Games)[^lucasfilm]
-`67` | Ocean
+`67` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)
 `69` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 `70` | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 `71` | Interplay
@@ -129,7 +129,7 @@ Code | Publisher
 `87` | Tsukuda Original
 `91` | Chunsoft
 `92` | Video system
-`93` | Ocean/Acclaim
+`93` | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)/[Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 `95` | [Varie](https://en.wikipedia.org/wiki/Varie)
 `96` | Yonezawa/s'pal
 `97` | Kaneko
@@ -281,16 +281,16 @@ HEX   | Licensee
 3E    | Gremlin
 41    | [Ubi Soft](https://en.wikipedia.org/wiki/Ubisoft)[^ubisoft]
 42    | [Atlus](https://en.wikipedia.org/wiki/Atlus)
-44    | Malibu
-46    | Angel              
+44    | [Malibu Interactive](https://en.wikipedia.org/wiki/Malibu_Comics)
+46    | [Angel](https://www.mobygames.com/company/5083/angel)
 47    | Spectrum Holoby    
 49    | Irem
 4A    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 4D    | Malibu             
 4F    | U.S. Gold
 50    | Absolute           
-51    | Acclaim            
-52    | Activision
+51    | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
+52    | [Activision](https://en.wikipedia.org/wiki/Activision)
 53    | American Sammy     
 54    | GameTek           
 55    | Park Place
@@ -303,7 +303,7 @@ HEX   | Licensee
 5D    | Tradewest          
 60    | Titus              
 61    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
-67    | Ocean Interactive              
+67    | [Ocean Software](https://en.wikipedia.org/wiki/Ocean_Software)
 69    | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 6E    | Elite Systems
 6F    | Electro Brain      
@@ -346,7 +346,7 @@ AA    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
 AC    | Toei Animation    
 AD    | Toho
 AF    | Namco             
-B0    | Acclaim           
+B0    | [Acclaim Entertainment](https://en.wikipedia.org/wiki/Acclaim_Entertainment)
 B1    | ASCII Corporation or Nexsoft
 B2    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
 B4    | [Square Enix](https://en.wikipedia.org/wiki/Square_Enix)
@@ -370,7 +370,7 @@ CB    | Vap
 CC    | Use Corporation               
 CD    | Meldac
 CE    | [Pony Canyon](https://en.wikipedia.org/wiki/Pony_Canyon)
-CF    | Angel              
+CF    | [Angel](https://www.mobygames.com/company/5083/angel)
 D0    | Taito
 D1    | Sofel              
 D2    | Quest              
@@ -393,7 +393,7 @@ E7    | Athena
 E8    | Asmik ACE Entertainment             
 E9    | Natsume            
 EA    | King Records
-EB    | Atlus              
+EB    | [Atlus](https://en.wikipedia.org/wiki/Atlus)
 EC    | Epic/Sony Records  
 EE    | IGS
 F0    | A Wave         

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -75,9 +75,9 @@ Sample licensee codes:
 Code | Publisher
 -----|-------------------------
 `00` | None
-`01` | Nintendo R&D1
+`01` | [Nintendo Research & Development 1](https://en.wikipedia.org/wiki/Nintendo_Research_%26_Development_1)
 `08` | Capcom
-`13` | EA (Electronic Arts)
+`13` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 `18` | Hudson Soft
 `19` | B-AI
 `20` | KSS
@@ -87,7 +87,7 @@ Code | Publisher
 `28` | Kemco Japan
 `29` | seta
 `30` | Viacom
-`31` | Nintendo
+`31` | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
 `32` | Bandai
 `33` | Ocean/Acclaim
 `34` | Konami
@@ -112,15 +112,15 @@ Code | Publisher
 `58` | Mattel
 `59` | Milton Bradley
 `60` | Titus
-`61` | Virgin Interactive
+`61` | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 `64` | LucasArts
 `67` | Ocean
-`69` | EA (Electronic Arts)
+`69` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 `70` | Infogrames
 `71` | Interplay
 `72` | Broderbund
 `73` | Sculptured Software
-`75` | The Sales Curve Limited
+`75` | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
 `78` | THQ
 `79` | Accolade
 `80` | Misawa Entertainment
@@ -253,24 +253,24 @@ Here is a list of known Old licensee codes ([source](https://raw.githubuserconte
 HEX   | Licensee
 ------|------------
 00    | None               
-01    | Nintendo           
-08    | Capcom
-09    | Hot-B              
-0A    | Jaleco             
-0B    | Coconuts Japan
-0C    | Elite Systems      
-13    | EA (Electronic Arts)    
-18    | Hudson Soft
-19    | ITC Entertainment  
-1A    | Yanoman            
-1D    | Japan Clary
-1F    | Virgin Interactive             
+01    | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
+08    | [Capcom](https://en.wikipedia.org/wiki/Capcom)
+09    | [HOT-B](https://en.wikipedia.org/wiki/Category:Hot_B_games)
+0A    | [Jaleco](https://en.wikipedia.org/wiki/Jaleco)
+0B    | [Coconuts Japan](https://en.wikipedia.org/wiki/Category:Coconuts_Japan_games)
+0C    | [Elite Systems](https://en.wikipedia.org/wiki/Elite_Systems)
+13    | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
+18    | [Hudson Soft](https://en.wikipedia.org/wiki/Hudson_Soft)
+19    | [ITC Entertainment](https://en.wikipedia.org/wiki/ITC_Entertainment)
+1A    | [Yanoman](https://en.wikipedia.org/wiki/Category:Yanoman_games)
+1D    | [Japan Clary](https://www.mobygames.com/company/7639/japan-clary-business/)
+1F    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 24    | PCM Complete       
 25    | San-X
 28    | Kotobuki Systems   
 29    | Seta               
 30    | Infogrames
-31    | Nintendo           
+31    | [Nintendo](https://en.wikipedia.org/wiki/Nintendo)
 32    | Bandai             
 33    | Indicates that the [New licensee code](<#0144–0145 — New licensee code>) should be used instead.
 34    | Konami             
@@ -285,7 +285,7 @@ HEX   | Licensee
 46    | Angel              
 47    | Spectrum Holoby    
 49    | Irem
-4A    | Virgin Interactive            
+4A    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 4D    | Malibu             
 4F    | U.S. Gold
 50    | Absolute           
@@ -302,16 +302,16 @@ HEX   | Licensee
 5C    | Naxat Soft
 5D    | Tradewest          
 60    | Titus              
-61    | Virgin Interactive
+61    | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
 67    | Ocean Interactive              
-69    | EA (Electronic Arts)    
+69    | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 6E    | Elite Systems
 6F    | Electro Brain      
 70    | Infogrames         
 71    | Interplay
 72    | Broderbund         
 73    | Sculptured Software   
-75    | The Sales Curve Limited
+75    | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
 78    | THQ             
 79    | Accolade           
 7A    | Triffix Entertainment
@@ -399,6 +399,10 @@ EE    | IGS
 F0    | A Wave         
 F3    | Extreme Entertainment  
 FF    | LJN
+
+[^sci]: Later known as [SCi (Sales Curve Interactive), then SCi Entertainment Group plc, then Eidos](https://en.wikipedia.org/wiki/SCi_Games), then accquired by [Square Enix](https://en.wikipedia.org/wiki/Square_Enix) in 2009.
+
+[^virgin]: Later known as [Virgin Mastertronic Ltd., then Virgin Interactive Entertainment, then Avalon Interactive Group, Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment).
 
 ## 014C — Mask ROM version number
 

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -94,7 +94,7 @@ Code | Publisher
 `35` | Hector
 `37` | Taito
 `38` | [Hudson Soft](https://en.wikipedia.org/wiki/Hudson_Soft)
-`39` | Banpresto
+`39` | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 `41` | [Ubi Soft](https://en.wikipedia.org/wiki/Ubisoft)[^ubisoft]
 `42` | [Atlus](https://en.wikipedia.org/wiki/Atlus)
 `44` | Malibu
@@ -113,7 +113,7 @@ Code | Publisher
 `59` | Milton Bradley
 `60` | Titus
 `61` | [Virgin Games Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment)[^virgin]
-`64` | LucasArts
+`64` | [Lucasfilm Games](https://en.wikipedia.org/wiki/Lucasfilm_Games)[^lucasfilm]
 `67` | Ocean
 `69` | [EA (Electronic Arts)](https://en.wikipedia.org/wiki/Electronic_Arts)
 `70` | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
@@ -130,7 +130,7 @@ Code | Publisher
 `91` | Chunsoft
 `92` | Video system
 `93` | Ocean/Acclaim
-`95` | Varie Corporation
+`95` | [Varie](https://en.wikipedia.org/wiki/Varie)
 `96` | Yonezawa/s'pal
 `97` | Kaneko
 `99` | Pack in soft
@@ -276,7 +276,7 @@ HEX   | Licensee
 34    | [Konami](https://en.wikipedia.org/wiki/Konami)
 35    | HectorSoft            
 38    | [Capcom](https://en.wikipedia.org/wiki/Capcom)
-39    | Banpresto          
+39    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 3C    | .Entertainment i   
 3E    | Gremlin
 41    | [Ubi Soft](https://en.wikipedia.org/wiki/Ubisoft)[^ubisoft]
@@ -309,7 +309,7 @@ HEX   | Licensee
 6F    | Electro Brain      
 70    | [Infogrames](https://en.wikipedia.org/wiki/Atari_SA)[^atari]
 71    | Interplay
-72    | Broderbund         
+72    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)
 73    | Sculptured Software   
 75    | [The Sales Curve Limited](https://en.wikipedia.org/wiki/SCi_Games)[^sci]
 78    | THQ             
@@ -334,7 +334,7 @@ HEX   | Licensee
 9A    | Nihon Bussan       
 9B    | Tecmo
 9C    | Imagineer          
-9D    | Banpresto          
+9D    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 9F    | Nova
 A1    | Hori Electric      
 A2    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
@@ -342,17 +342,17 @@ A4    | [Konami](https://en.wikipedia.org/wiki/Konami)
 A6    | Kawada             
 A7    | Takara             
 A9    | Technos Japan
-AA    | Broderbund         
+AA    | [Broderbund](https://en.wikipedia.org/wiki/Broderbund)         
 AC    | Toei Animation    
 AD    | Toho
 AF    | Namco             
 B0    | Acclaim           
 B1    | ASCII Corporation or Nexsoft
-B2    | Bandai             
-B4    | Square Enix               
+B2    | [Bandai](https://en.wikipedia.org/wiki/Bandai)
+B4    | [Square Enix](https://en.wikipedia.org/wiki/Square_Enix)
 B6    | HAL Laboratory
 B7    | SNK                
-B9    | Pony Canyon        
+B9    | [Pony Canyon](https://en.wikipedia.org/wiki/Pony_Canyon)
 BA    | Culture Brain
 BB    | Sunsoft            
 BD    | Sony Imagesoft    
@@ -369,7 +369,7 @@ CA    | Ultra
 CB    | Vap                
 CC    | Use Corporation               
 CD    | Meldac
-CE    | Pony Canyon    
+CE    | [Pony Canyon](https://en.wikipedia.org/wiki/Pony_Canyon)
 CF    | Angel              
 D0    | Taito
 D1    | Sofel              
@@ -378,7 +378,7 @@ D3    | Sigma Enterprises
 D4    | ASK Kodansha Co.       
 D6    | Naxat Soft         
 D7    | Copya System
-D9    | Banpresto          
+D9    | [Banpresto](https://en.wikipedia.org/wiki/Banpresto)
 DA    | Tomy               
 DB    | LJN
 DD    | NCS                
@@ -387,7 +387,7 @@ DF    | Altron
 E0    | Jaleco             
 E1    | Towa Chiki          
 E2    | Yutaka
-E3    | Varie Corporation  
+E3    | [Varie](https://en.wikipedia.org/wiki/Varie)
 E5    | Epcoh              
 E7    | Athena
 E8    | Asmik ACE Entertainment             
@@ -403,6 +403,8 @@ FF    | LJN
 [^ubisoft]: Later known as [Ubisoft](https://en.wikipedia.org/wiki/Ubisoft).
 
 [^virgin]: Later known as [Virgin Mastertronic Ltd., then Virgin Interactive Entertainment, then Avalon Interactive Group, Ltd.](https://en.wikipedia.org/wiki/Virgin_Interactive_Entertainment).
+
+[^lucasfilm]: Later known as [LucasArts](https://en.wikipedia.org/wiki/Lucasfilm_Games) between 1990-2021.
 
 [^atari]: Later known as [Atari SA](https://en.wikipedia.org/wiki/Atari_SA).
 


### PR DESCRIPTION
Companies codes I cannot confirm:
- `San-X`, old code `0x25` new code "25"
- `.Entertainment i` old code `0x3C`
- `Yonezawa/s'pal`, old code `0x96` new code "96"