### PR TITLE
Addressed lints

### DIFF
--- a/preproc/src/bit_descrs.rs
+++ b/preproc/src/bit_descrs.rs
@@ -222,7 +222,7 @@ impl<'input> BitDescrAttrs<'input> {
                 let right = cap
                     .get(2)
                     .map_or(left, |end_match| end_match.as_str().parse().unwrap());
-                let name = undo_escapes(&cap.get(3).unwrap().as_str());
+                let name = undo_escapes(cap.get(3).unwrap().as_str());
 
                 // Perform some sanity checks.
                 let Some((mut start, len)) = if increasing {

--- a/renderer/src/main.rs
+++ b/renderer/src/main.rs
@@ -10,15 +10,13 @@
 use anyhow::Context;
 use globwalk::{FileType, GlobWalkerBuilder};
 use lazy_static::lazy_static;
-use mdbook::errors::{Error, Result};
+use mdbook::errors::Result;
 use mdbook::renderer::{HtmlHandlebars, RenderContext, Renderer};
 use regex::Regex;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::io::{BufRead, BufReader, BufWriter};
 use std::path::PathBuf;
-use std::process::Command;
-use std::str::FromStr;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use url::Url;
 


### PR DESCRIPTION
While compiling the renderer, there were some warnings about unused imports. After I fixed that, I ran clippy in both renderer and preproc and addressed one lint that came up there.