### PR TITLE
Describe serial interrupt in serial interrupt section

### DIFF
--- a/src/Interrupt_Sources.md
+++ b/src/Interrupt_Sources.md
@@ -56,42 +56,8 @@ The timer interrupt [is requested] every time that the timer overflows (that is,
 
 ## INT $58 — Serial interrupt
 
-**XXXXXX\...**
-
-Transmitting and receiving serial data is done simultaneously. The
-received data is automatically stored in SB.
-
-The serial I/O port on the Game Boy is a very simple setup and is crude
-compared to standard RS-232 (IBM-PC) or RS-485 (Macintosh) serial ports.
-There are no start or stop bits.
-
-During a transfer, a byte is shifted in at the same time that a byte is
-shifted out. The rate of the shift is determined by whether the clock
-source is internal or external. The most significant bit is shifted in
-and out first.
-
-When the internal clock is selected, it drives the clock pin on the game
-link port and it stays high when not used. During a transfer it will go
-low eight times to clock in/out each bit.
-
-The state of the last bit shifted out determines the state of the output
-line until another transfer takes place.
-
-If a serial transfer with internal clock is performed and no external
-Game Boy is present, a value of \$FF will be received in the transfer.
-
-The following code initiates the process of shifting \$75 out the serial
-port and a byte to be shifted into \$FF01:
-
-```rgbasm
-   ld a, $75
-   ld [$FF01], a
-   ld a, $81
-   ld [$FF02], a
-```
-
-The Game Boy does not support wake-on-LAN. Completion of an externally
-clocked serial transfer does not exit STOP mode.
+The serial interrupt [is requested] upon completion of a serial data transfer.
+In other words, eight serial clock cycles after starting a transfer (by setting [SC](<#FF02 — SC: Serial transfer control>) bit 7), the incoming data will be in [SB](<#FF01 — SB: Serial transfer data>) and the interrupt will be requested.
 
 ## INT $60 — Joypad interrupt
 


### PR DESCRIPTION
This removes the (out of place) description of the serial port from the 'Interrupt Sources' page and replaces it with a description of when the serial interrupt is requested (which is the main thing that should be there).

This fixes #528, but I haven't moved any of the deleted text to the Serial Data Transfer page. It was almost all redundant. I don't think we're losing anything.