### PR TITLE
WIP:  Port "Gameboy sound hardware" from the old wiki

### DIFF
--- a/src/Audio.md
+++ b/src/Audio.md
@@ -81,7 +81,7 @@ Internally, all envelopes are ticked at 64 Hz, and every 1–7 of those ticks, t
 All channels can be individually set to automatically shut themselves down after a certain amount of time.
 
 If the functionality is enabled, a channel's **length timer** ticks up[^len_cnt_dir] at 256 Hz (tied to [DIV-APU](<#DIV-APU>)) from the value it's initially set at.
-When the length timer reaches 64, the channel is turned off.
+When the length timer reaches 64 (Ch1 and Ch2) or 256 (Ch3), the channel is turned off.
 
 ### Frequency
 

--- a/src/Audio.md
+++ b/src/Audio.md
@@ -27,6 +27,17 @@ It refuses to run on the GBA for a different reason: the developer couldn't figu
 
 :::
 
+Each channel contains components that control different aspects of sound generation:
+
+| Channel  | Sweep | Frequency      | Wave Form | Length Timer | Volume   |
+|----------|-------|----------------|-----------|--------------|----------|
+| Square 1 | Sweep | Period Counter | Duty      | Length Timer | Envelope |
+| Square 2 |       | Period Counter | Duty      | Length Timer | Envelope |
+| Wave     |       | Period Counter | Wave      | Length Timer | Volume   |
+| Noise    |       | Period Counter | LFSR      | Length Timer | Envelope |
+
+These components are controlled by writing to the [audio registers](<#Audio Registers>).
+
 [^speaker_mono]:
 The speaker merges back the two channels, losing the stereo aspect entirely.
 

--- a/src/Audio_Registers.md
+++ b/src/Audio_Registers.md
@@ -24,6 +24,8 @@ One of the pitfalls of the `NRxy` naming convention is that the register's purpo
 
 - **Audio on/off** (*Read/Write*): This controls whether the APU is powered on at all (akin to [`LCDC` bit 7](<#LCDC.7 — LCD enable>)).
   Turning the APU off drains less power (around 16%), but clears all APU registers and makes them read-only until turned back on, except `NR52`[^dmg_apu_off].
+  Turning the APU off, however, does not affect [Wave RAM](<#FF30–FF3F — Wave pattern RAM>), which can always be read/written, nor the [DIV-APU](<#DIV-APU>) counter.
+
 - **CH<var>n</var> on?** (*Read-only*): Each of these four bits allows checking whether channels are active[^nr52_dac].
   Writing to those does **not** enable or disable the channels, despite many emulators behaving as if.
 

--- a/src/Audio_details.md
+++ b/src/Audio_details.md
@@ -228,3 +228,45 @@ The APU was reworked pretty heavily for the GBA, which introduces some slightly 
 None of the additional features (more wave RAM, digital FIFOs, etc.) are available to CGB programs.
 
 [`NR51`]: <#FF25 — NR51: Sound panning>
+
+## Obscure Behavior
+
+- The volume envelope and sweep timers treat a period of 0 as 8.
+- Just after powering on, the first duty step of Ch1 and Ch2 after they are triggered for the first time is played
+  as if it were 0. Also, the duty cycle clocking is disabled until the first trigger.
+- When triggering Ch3, the first sample to play is the previous one still in the high nibble of the sample buffer, and the next sample is the second nibble from the wave table. This is because it doesn't load the first byte on trigger like it *should*.
+  The first nibble from the wave table is thus not played until the waveform loops.
+- When triggering Ch1 and Ch2, the low two bits of the frequency timer are NOT modified.
+- Extra length clocking occurs when writing to NRx4 when the DIV-APU next step is one that doesn't clock the length timer. In this case, if the length timer was PREVIOUSLY disabled and now enabled and the length timer is not zero, it is decremented. If this decrement makes it zero and trigger is clear, the channel is disabled. On the CGB-02, the length timer only has to have been disabled before; the current length enable state doesn't matter. This breaks at least one game (Prehistorik Man), and was fixed on CGB-04 and CGB-05.
+- If a channel is triggered when the DIV-APU next step is one that doesn't clock the length timer and the length timer is now enabled and length is being set to 64 (256 for wave channel) because it was previously zero, it is set to 63 instead (255 for wave channel).
+- If a channel is triggered when the DIV-APU next step will clock the volume envelope, the envelope's timer is reloaded with one greater than it would have been.
+- Using a noise channel clock shift of 14 or 15 results in the LFSR receiving no clocks.
+- Clearing the sweep direction bit in NR10 after at least one sweep calculation has been made using the substraction mode since the last trigger causes the channel to be immediately disabled. This prevents you from having the sweep lower the frequency then raise the frequency without a trigger inbetween.
+- Triggering the wave channel on the DMG while it reads a sample byte will alter the first four bytes of wave RAM. If the channel was reading one of the first four bytes, the only first byte will be rewritten with the byte being read. If the channel was reading one of the later 12 bytes, the first FOUR bytes of wave RAM will be rewritten with the four aligned bytes that the read was from (bytes 4-7, 8-11, or 12-15); for example if it were reading byte 9 when it was retriggered, the first four bytes would be rewritten with the contents of bytes 8-11. To avoid this corruption you should stop the wave by writing 0 then $80 to NR30 before triggering it again. The game Duck Tales encounters this issue part way through most songs.
+- "Zombie" mode: the volume can be manually altered while a channel is playing by writing to NRx2. Behavior depends on the old and new values of NRx2, and whether the envlope has stopped automatic updates. The CGB-02 and CGB-04 are the most consistent:
+  * If the old envelope period was zero and the envelope is still doing automatic updates, volume is incremented by 1, otherwise if the envelope was in decrease mode, volume is incremented by 2.
+  * If the mode was changed (increase to decrease or decrease to increase), volume is set to 16-volume.
+  * Only the low 4 bits of volume are kept after the above operations.
+
+Other models behave differently, especially the DMG units which have crazy behavior in some cases. The only useful consistent behavior is using increase mode with a period of zero in order to increment the volume by 1. That is, write $V8 to NRx2 to set the initial volume to V before triggering the channel, then write $08 to NRx2 to increment the volume as the sound plays (repeat 15 times to decrement the volume by 1). This allows manual volume control on all units tested.
+
+- When all four channel DACs are off, the master volume units are disconnected from the sound output and the output level becomes 0. When any channel DAC is on, a high-pass filter capacitor is connected which slowly removes any DC component from the signal. The following code applied at 4194304 Hz implements these two behaviors for one of the DMG output channels (unoptimized floating point for clarity):
+
+```c
+static double capacitor = 0.0;
+
+double high_pass( double in, bool dacs_enabled )
+{
+     double out = 0.0;
+     if ( dacs_enabled )
+     {
+         out = in - capacitor;
+
+         // capacitor slowly charges to 'in' via their difference
+         capacitor = in - out * 0.999958; // use 0.998943 for MGB&CGB
+     }
+     return out;
+}
+```
+
+The charge factor can be calculated for any output sampling rate as 0.999958^(4194304/rate). So if you were applying high_pass() at 44100 Hz, you'd use a charge factor of 0.996.


### PR DESCRIPTION
Closes #552. Each section from the old wiki corresponds to a commit.
I encountered the following issues while porting some sections:

- The Channels section diagram is pretty ugly, I would like recommendations on how to redo it.
- The Frame Sequencer section diagram has been skipped, since it
doesn't match with SameBoy source, and I think that's more accurate.
- The VIN mixing section is pretty bare and I don't know if the information in there
is useful, so I skipped it.
- The obscure behavior section could probably be refactored to be in Audio Registers,
and Audio Details, but I don't know if that would make the rest of the section more bothersome
to read.
- I don't think a lot of version differences are mentioned in the rest of the page,
so I skipped them as well.
