### PR TITLE
MBC6: Fix description of flash commands

### DIFF
--- a/src/MBC6.md
+++ b/src/MBC6.md
@@ -98,26 +98,24 @@ either 4 or 6 and Y to 5 or 7, depending on the bank region:
 
 ```
 ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------------
-2:Y555=$AA    1:XAAA=$55    2:Y555=$80    2:Y555=$AA    1:XAAA=$55    ?:X000=$30    Erase sector\* (set 8 kB region to $FFs)
-2:Y555=$AA    1:XAAA=$55    2:Y555=$80    2:Y555=$AA    1:XAAA=$55    ?:Y555=$10    Erase chip\* (set entire flash to $FFs)
-2:Y555=$AA    1:XAAA=$55    2:Y555=$90                                                 ID mode (reads out JEDEC ID (C2,81) at $X000)
-2:Y555=$AA    1:XAAA=$55    2:Y555=$A0                                                 Program mode\*
-2:Y555=$AA    1:XAAA=$55    2:Y555=$F0                                                 Exit ID/erase chip mode
-2:Y555=$AA    1:XAAA=$55    ?:X000=$F0                                                 Exit erase sector mode
-?:????=$F0                                                                               Exit program mode
+2:Y555=$AA    1:XAAA=$55    2:Y555=$80    2:Y555=$AA    1:XAAA=$55    ?:????=$30    Erase sector\* (set 128 KiB region to $FFs)
+2:Y555=$AA    1:XAAA=$55    2:Y555=$80    2:Y555=$AA    1:XAAA=$55    2:Y555=$10    Erase chip\* (set entire flash to $FFs)
+2:Y555=$AA    1:XAAA=$55    2:Y555=$90                                              ID mode (reads out JEDEC ID (C2,81) at $X000)
+2:Y555=$AA    1:XAAA=$55    2:Y555=$A0                                              Program mode\*
+?:????=$F0                                                                          Exit ID, erase or program mode
 ------------- ------------- ------------- ------------- ------------- ------------- ------------------------------------------------
 ```
 
 Commands marked with \* require the Write Enable bit to be 1. These will
 make the flash read out status bytes instead of values. A status of $80
 means the operation has finished and you should exit the mode using the
-appropriate command. A status of $10 indicates a timeout.
+$F0 command. A status of $10 indicates a timeout.
 
 Programming must be done by first erasing a sector, activating write
-mode, writing out 128 bytes (aligned), then writing a 0 to the final
-address to commit the write, waiting for the status to indicate
-completion, and writing $F0 to the final address again to exit program
-mode. If a sector is not erased first programming will not work
+mode, writing out 128 bytes (aligned), then writing any value (except
+$F0) to the final address again to commit the write, waiting for the
+status to indicate completion, and writing $F0 to any address to exit
+program mode. If a sector is not erased first programming will not work
 properly. In some cases it will only allow the stored bytes to be anded
 instead of replaced; in others it just won't work at all. The only way
 to set the bits back to 1 is to erase the sector entirely. It is
@@ -125,6 +123,16 @@ recommended to check the flash to make sure all bytes were written
 properly and re-write (without erasing) the 128 byte block if some bits
 didn't get set to 0 properly. After writing all blocks in a sector
 Flash Write Enable should be set to 0.
+
+The last byte of the erase sector command needs to be written to an
+address that lies within the sector that you want to erase. There are
+eight sectors, 128 KiB each. For example, to erase sector 2, the last
+byte ($30) has to be written to address $40000. The bank number for
+that address can be calculated like this: 2 \* 16, where 2 is the sector
+number. Therefore, for erasing sector 2, before writing the last byte
+($30), write 32 to $2000 to select the bank, and then write $30 to
+$4000 or any other address between $4000-$5FFF, the lower address bits
+are not relevant.
 
 ## External links
 


### PR DESCRIPTION
I found some mistakes in the flash commands description:
* Erase sector size is actually 128 KiB, not 8 kB.
* The address of the last byte in the command sequence for "erase sector"
  must be an address within the erased sector.
* There is really only one "exit mode" command that works for all modes.
* The data being written to the final address in programming mode doesn't
  have to be 0. It can be anything but $F0.
* $F0 doesn't have to be written to the final address. It can be written
  to any address.

I experimented with the Nintendo Power GB Memory cartridges and with Net
de Get. I wrote a documentation here:
http://iceboy.a-singer.de/doc/np_gb_memory.html

There are things not documented in Pan Docs:
* The flash in Net de Get also has a hidden 256 byte region that can be read
  and programmed.
* It has commands for protecting and "unprotecting" sector 0.

I don't know, if you want to add them. Maybe those things are not used by
Net de Get. I can't tell, because all my Net de Get cartridges came with an
empty flash.