### PR TITLE
Clarify palettes bootrom behavior

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -41,7 +41,8 @@ docker build -t pandocs .
 
 If you prefer to install every dependency locally:
 
-1. Install [Rust](https://www.rust-lang.org/tools/install), [mdBook](https://github.com/rust-lang/mdBook#readme), and [Python 3](https://www.python.org/downloads) (3.9 or an earlier version).
+1. Install [Rust](https://www.rust-lang.org/tools/install), [mdBook](https://github.com/rust-lang/mdBook#readme), and [Python 3](https://www.python.org/downloads) (version 3.9 or newer).
+
   mdBook is the tool rendering the documentation, Rust is used for some custom plugins and Python scripts are used to render some images. E.g.:
   ```sh
   # Install Rust using rustup

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -89,7 +89,7 @@ color #0 uninitialized.
 
 :::tip NOTE
 
-For most of the cases the boot ROM leaves all object colors uninitialized (and thus somewhat random),
+For most of the cases the boot ROM leaves all object colors uninitialized (and thus somewhat random/unreliable),
 aside from setting the first byte of OBJ0 color #0 to $00, which is unused.
 
 Only in compatibility for DMG mode, the boot ROM sets the first 2 object palettes which are

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -89,8 +89,11 @@ color #0 uninitialized.
 
 :::tip NOTE
 
-The boot ROM leaves all object colors uninitialized (and thus somewhat random),
+For most of the cases the boot ROM leaves all object colors uninitialized (and thus somewhat random),
 aside from setting the first byte of OBJ0 color #0 to $00, which is unused.
+
+Only in compatibility for DMG mode, the boot ROM sets the first 2 object palettes which are
+used by OBP0/OBP1, for more [see](./Power_Up_Sequence.md#compatibility-palettes).
 
 :::
 

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -93,7 +93,7 @@ In CGB mode, the boot ROM leaves all object colors uninitialized (and thus somew
 aside from setting the first byte of OBJ0 color #0 to $00, which is unused.
 
 In DMG compatibility mode, the boot ROM sets the first 2 object palettes which are
-used by OBP0/OBP1, for more [see](./Power_Up_Sequence.md#compatibility-palettes).
+used by OBP0/OBP1, [as explained here](<#Compatibility palettes>).
 
 :::
 

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -89,10 +89,10 @@ color #0 uninitialized.
 
 :::tip NOTE
 
-For most of the cases the boot ROM leaves all object colors uninitialized (and thus somewhat random/unreliable),
+In CGB mode, the boot ROM leaves all object colors uninitialized (and thus somewhat random/unreliable),
 aside from setting the first byte of OBJ0 color #0 to $00, which is unused.
 
-Only in compatibility for DMG mode, the boot ROM sets the first 2 object palettes which are
+In DMG compatibility mode, the boot ROM sets the first 2 object palettes which are
 used by OBP0/OBP1, for more [see](./Power_Up_Sequence.md#compatibility-palettes).
 
 :::


### PR DESCRIPTION
I found the lack of a reference to the boot up sequence and the statement about the bootrom setting the object palettes confusing.
I hope this helps :)

Also update `DEPLOY.md` recommended python version