### PR TITLE
Add CPU mode select register - KEY0

### DIFF
--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -221,22 +221,28 @@ does not include an infra-red port.
 
 ### FF4C — KEY0 (CGB Mode only): CPU mode select 
 
-This register is not officaly documented and this info have been gathered from leaks ([translated here](https://github.com/ISSOtm/gb-bootroms/commit/8513822a812ad9153b1618490d504c212ed61ed2))
+This GBC-only register (which is not officaly documented) is written only by the CGB boot ROM,
+as it gets locked after the bootrom finish execution (by a write to the [BANK register](<#Monochrome models (DMG0, DMG, MGB)>)).
+
+Once it is locked, the behavior of the system can't be changed without a reset (This behavior can be observed using [this test ROM](https://github.com/alloncm/MagenTests?tab=readme-ov-file#key0-cpu-mode-register-lock-after-boot)).
+
+As a result of the above most of the behavior is not directly testable without hardware manipulation.
+Even though we can't test it's behavior directly we can inspect the disassembly of the CGB bootrom and infer the following: 
 
 {{#bits 8 >
-   "KEY0" 3-2:"CPU mode"
+   "KEY0" 2:"DMG compatibility mode"
 }}
 
-CPU mode can be one of those 2 bits values:
-- 0 - CGB mode (for execution of CGB supporting cartridges)
-- 1 - DMG mode (for execution of DMG exclusive cartridges)
-- 2 - PGB1 mode
-- 3 - PGB2 mode
+- **DMG compatibility mode**: `0` = Disabled (full CGB mode, for regular CGB cartridges), `1` = Enabled (for DMG only cartridges)
+
+#### Bit 3 and "PGB mode"
+
+It has been speculated based on leaked documents that setting bit 3 is related to a special mode called "PGB" for controlling the LCD externally.
+However, this has not been independently verified.
 
 :::tip Research needed
 
-The PGB mode is not well researched or documented yet.
-Help is welcome!
+Bit 3 and the "PGB mode" are not well researched or documented yet, any help is welcome!
 
 :::
 
@@ -246,7 +252,7 @@ This register serves as a flag for which object priority mode to use. While
 the DMG prioritizes objects by x-coordinate, the CGB prioritizes them by
 location in OAM. This flag is set by the CGB bios after checking the game's CGB compatibility.
 
-OPRI has an effect if a PGB value (`0xX8`, `0xXC`) is written to [KEY0](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) but STOP hasn't been executed yet, and the write takes effect instantly.
+OPRI has an effect if a [PGB](<#Bit 3 and "PGB mode">) value (`0xX8`, `0xXC`) is written to [KEY0](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) but STOP hasn't been executed yet, and the write takes effect instantly.
 
 :::warning TO BE VERIFIED
 

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -224,10 +224,10 @@ does not include an infra-red port.
 This GBC-only register (which is not officially documented) is written only by the CGB boot ROM,
 as it gets locked after the bootrom finish execution (by a write to the [BANK register](<#Monochrome models (DMG0, DMG, MGB)>)).
 
-Once it is locked, the behavior of the system can't be changed without a reset (This behavior can be observed using [this test ROM](https://github.com/alloncm/MagenTests?tab=readme-ov-file#key0-cpu-mode-register-lock-after-boot)).
+Once it is locked, the behavior of the system can't be changed without a reset (this behavior can be observed using [this test ROM](https://github.com/alloncm/MagenTests?tab=readme-ov-file#key0-cpu-mode-register-lock-after-boot)).
 
 As a result of the above most of the behavior is not directly testable without hardware manipulation.
-Even though we can't test it's behavior directly we can inspect the disassembly of the CGB bootrom and infer the following: 
+Even though we can't test its behavior directly we can inspect the disassembly of the CGB bootrom and infer the following: 
 
 {{#bits 8 >
    "KEY0" 2:"DMG compatibility mode"
@@ -240,7 +240,6 @@ Even though we can't test it's behavior directly we can inspect the disassembly 
 :::tip Research needed
 
 It has been speculated that setting bit 3 is related to a special mode called "PGB" for controlling the LCD externally.
-However, this has not been independently verified.
 
 This mode is not well researched nor documented yet, you are welcome to help [here!](https://github.com/gbdev/pandocs/issues/581)
 

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -219,13 +219,34 @@ ON/OFF pulses (length 10us ON, 17.5us OFF each) instead of a permanent
 880us LED ON signal. Even though being generally CGB compatible, the GBA
 does not include an infra-red port.
 
+### FF4C — KEY0 (CGB Mode only): CPU mode select 
+
+This register is not officaly documented and this info have been gathered from leaks ([translated here](https://github.com/ISSOtm/gb-bootroms/commit/8513822a812ad9153b1618490d504c212ed61ed2))
+
+{{#bits 8 >
+   "KEY0" 3-2:"CPU mode"
+}}
+
+CPU mode can be one of those 2 bits values:
+- 0 - CGB mode (for execution of CGB supporting cartridges)
+- 1 - DMG mode (for execution of DMG exclusive cartridges)
+- 2 - PGB1 mode
+- 3 - PGB2 mode
+
+:::tip Research needed
+
+The PGB mode is not well researched or documented yet.
+Help is welcome!
+
+:::
+
 ### FF6C — OPRI (CGB Mode only): Object priority mode
 
 This register serves as a flag for which object priority mode to use. While
 the DMG prioritizes objects by x-coordinate, the CGB prioritizes them by
 location in OAM. This flag is set by the CGB bios after checking the game's CGB compatibility.
 
-OPRI has an effect if a PGB value (`0xX8`, `0xXC`) is written to KEY0 but STOP hasn't been executed yet, and the write takes effect instantly.
+OPRI has an effect if a PGB value (`0xX8`, `0xXC`) is written to [KEY0](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) but STOP hasn't been executed yet, and the write takes effect instantly.
 
 :::warning TO BE VERIFIED
 

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -221,7 +221,7 @@ does not include an infra-red port.
 
 ### FF4C — KEY0 (CGB Mode only): CPU mode select 
 
-This GBC-only register (which is not officaly documented) is written only by the CGB boot ROM,
+This GBC-only register (which is not officially documented) is written only by the CGB boot ROM,
 as it gets locked after the bootrom finish execution (by a write to the [BANK register](<#Monochrome models (DMG0, DMG, MGB)>)).
 
 Once it is locked, the behavior of the system can't be changed without a reset (This behavior can be observed using [this test ROM](https://github.com/alloncm/MagenTests?tab=readme-ov-file#key0-cpu-mode-register-lock-after-boot)).

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -235,14 +235,14 @@ Even though we can't test it's behavior directly we can inspect the disassembly 
 
 - **DMG compatibility mode**: `0` = Disabled (full CGB mode, for regular CGB cartridges), `1` = Enabled (for DMG only cartridges)
 
-#### Bit 3 and "PGB mode"
-
-It has been speculated based on leaked documents that setting bit 3 is related to a special mode called "PGB" for controlling the LCD externally.
-However, this has not been independently verified.
+#### PGB mode
 
 :::tip Research needed
 
-Bit 3 and the "PGB mode" are not well researched or documented yet, any help is welcome!
+It has been speculated that setting bit 3 is related to a special mode called "PGB" for controlling the LCD externally.
+However, this has not been independently verified.
+
+This mode is not well researched nor documented yet, you are welcome to help [here!](https://github.com/gbdev/pandocs/issues/581)
 
 :::
 
@@ -252,7 +252,7 @@ This register serves as a flag for which object priority mode to use. While
 the DMG prioritizes objects by x-coordinate, the CGB prioritizes them by
 location in OAM. This flag is set by the CGB bios after checking the game's CGB compatibility.
 
-OPRI has an effect if a [PGB](<#Bit 3 and "PGB mode">) value (`0xX8`, `0xXC`) is written to [KEY0](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) but STOP hasn't been executed yet, and the write takes effect instantly.
+OPRI has an effect if a [PGB](<#PGB mode>) value (`0xX8`, `0xXC`) is written to [KEY0](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) but STOP hasn't been executed yet, and the write takes effect instantly.
 
 :::warning TO BE VERIFIED
 

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -86,7 +86,9 @@ Then, like the monochrome boot ROMs, the header logo is checked *from the buffer
 For unknown reasons, however, only the first half of the logo is checked, despite the full logo being present in the HRAM buffer.
 
 Finally, the boot ROM fades all BG palettes to white, and sets the hardware to compatibility mode.
-If [the CGB compatibility byte](<#0143 — CGB flag>) indicates CGB compatibility, the byte is written directly to `KEY0` ($FF4C), potentially enabling PGB mode; otherwise, $04 is written to `KEY0` (enabling DMG compatibility mode in the CPU), $01 is written to [`OPRI`](<#FF6C — OPRI (CGB Mode only): Object priority mode>) (enabling [DMG OBJ priority](<#Object Priority and Conflicts>)), and the [compatibility palettes](<#Compatibility palettes>) are written.
+If [the CGB compatibility byte](<#0143 — CGB flag>) indicates CGB compatibility, the byte is written directly to [`KEY0`](<#FF4C — KEY0 (CGB Mode only): CPU mode select>),
+potentially enabling PGB mode; otherwise, $04 is written to `KEY0` (enabling DMG compatibility mode in the CPU),
+$01 is written to [`OPRI`](<#FF6C — OPRI (CGB Mode only): Object priority mode>) (enabling [DMG OBJ priority](<#Object Priority and Conflicts>)), and the [compatibility palettes](<#Compatibility palettes>) are written.
 Additionally, the DMG logo tilemap is written [if the compatibility requests it](<#Compatibility palettes>).
 
 Like all other boot ROMs, the last thing the color boot ROMs do is hand off execution at the same time as they unmap themselves, though they write $11 instead of $01 or $FF.

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -86,7 +86,7 @@ Then, like the monochrome boot ROMs, the header logo is checked *from the buffer
 For unknown reasons, however, only the first half of the logo is checked, despite the full logo being present in the HRAM buffer.
 
 Finally, the boot ROM fades all BG palettes to white, and sets the hardware to compatibility mode.
-If [the CGB compatibility byte](<#0143 — CGB flag>) indicates CGB compatibility, the byte is written directly to [`KEY0`](<#FF4C — KEY0 (CGB Mode only): CPU mode select>), potentially [enabling "PGB mode"](<#Bit 3 and "PGB mode">);
+If [the CGB compatibility byte](<#0143 — CGB flag>) indicates CGB compatibility, the byte is written directly to [`KEY0`](<#FF4C — KEY0 (CGB Mode only): CPU mode select>), potentially [enabling "PGB mode"](<#PGB mode>);
 otherwise, $04 is written to [`KEY0`](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) (enabling DMG compatibility mode in the CPU),
 $01 is written to [`OPRI`](<#FF6C — OPRI (CGB Mode only): Object priority mode>) (enabling [DMG OBJ priority](<#Object Priority and Conflicts>)), and the [compatibility palettes](<#Compatibility palettes>) are written.
 Additionally, the DMG logo tilemap is written [if the compatibility requests it](<#Compatibility palettes>).

--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -86,8 +86,8 @@ Then, like the monochrome boot ROMs, the header logo is checked *from the buffer
 For unknown reasons, however, only the first half of the logo is checked, despite the full logo being present in the HRAM buffer.
 
 Finally, the boot ROM fades all BG palettes to white, and sets the hardware to compatibility mode.
-If [the CGB compatibility byte](<#0143 — CGB flag>) indicates CGB compatibility, the byte is written directly to [`KEY0`](<#FF4C — KEY0 (CGB Mode only): CPU mode select>),
-potentially enabling PGB mode; otherwise, $04 is written to `KEY0` (enabling DMG compatibility mode in the CPU),
+If [the CGB compatibility byte](<#0143 — CGB flag>) indicates CGB compatibility, the byte is written directly to [`KEY0`](<#FF4C — KEY0 (CGB Mode only): CPU mode select>), potentially [enabling "PGB mode"](<#Bit 3 and "PGB mode">);
+otherwise, $04 is written to [`KEY0`](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) (enabling DMG compatibility mode in the CPU),
 $01 is written to [`OPRI`](<#FF6C — OPRI (CGB Mode only): Object priority mode>) (enabling [DMG OBJ priority](<#Object Priority and Conflicts>)), and the [compatibility palettes](<#Compatibility palettes>) are written.
 Additionally, the DMG logo tilemap is written [if the compatibility requests it](<#Compatibility palettes>).
 

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -56,14 +56,7 @@ Value | Meaning
 `$80` | The game supports CGB enhancements, but is backwards compatible with monochrome Game Boys
 `$C0` | The game works on CGB only (the hardware ignores bit 6, so this really functions the same as `$80`)
 
-Values with bit 7 and either bit 2 or 3 set will switch the Game Boy into a special non-CGB-mode called "PGB mode".
-
-:::tip Research needed
-
-The PGB mode is not well researched or documented yet.
-Help is welcome!
-
-:::
+Setting bit 7 will trigger a write of bits 2-3 to [KEY0](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) which sets the CPU mode.
 
 ## 0144–0145 — New licensee code
 

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -56,7 +56,7 @@ Value | Meaning
 `$80` | The game supports CGB enhancements, but is backwards compatible with monochrome Game Boys
 `$C0` | The game works on CGB only (the hardware ignores bit 6, so this really functions the same as `$80`)
 
-Setting bit 7 will trigger a write of bits 2-3 to [KEY0](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) which sets the CPU mode.
+Setting bit 7 will trigger a write of this register value to [KEY0 register](<#FF4C — KEY0 (CGB Mode only): CPU mode select>) which sets the CPU mode.
 
 ## 0144–0145 — New licensee code
 


### PR DESCRIPTION
Add the register description to the CGB Registers page and updated the CGB flag cartridge and the Power Up Sequence with refs to the new register.

This PR mostly uses https://github.com/ISSOtm/gb-bootroms/commit/8513822a812ad9153b1618490d504c212ed61ed2 as a source for the register description which is based on leaks (hope it is OK).

## Edit:
This PR now does not uses leaked documents as a source but acknowledge them as other sections are relaying on them.

## Edit 2:
This PR now does not uses leaked documents.