### PR TITLE
Update Wording of SC Check in Serial Data Transfer Page

### DIFF
--- a/src/Serial_Data_Transfer_(Link_Cable).md
+++ b/src/Serial_Data_Transfer_(Link_Cable).md
@@ -41,9 +41,8 @@ incoming bit is shifted in from the other side:
 
 The master Game Boy will load up a data byte in SB and then set
 SC to \$81 (Transfer requested, use internal clock). It will be notified
-that the transfer is complete in two ways: SC's Bit 7 will be cleared
-(that is, SC will be set up \$01), and also a [Serial interrupt](<#INT $58 — Serial interrupt>)
-will be requested.
+that the transfer is complete in two ways: SC's Bit 7 will be cleared, and a [Serial interrupt](<#INT $58 — Serial interrupt>)
+will be requested. When checking SC to determine if the transfer is complete, make sure to only read SC's Bit 7.
 
 The other Game Boy will load up a data byte and has to set SC's
 Bit 7 (that is, SC=\$80) to enable the serial port. The externally clocked


### PR DESCRIPTION
-Updated the wording on the Serial Transfer Page to not mention checking for $01, as this is incorrect. Removed that line and added a sentence to describe remind the reader to only check Bit 7. This may be implied after removing the text in parentheses, but may not hurt to stress the importance of only checking Bit 7.
-While testing in Emulicious, I was checking comparing SC to $01 and my code wasn't working because SC was actually equal to $7F. Bit 7 is indeed 0, but the other bits changed, thus making checking for $01 incorrect, and maybe situational. I was under the assumption that the other bits wouldn't change after I set SC to $81.