### PR TITLE
Correction regarding MBC2 RAM enable register

### DIFF
--- a/src/MBC2.md
+++ b/src/MBC2.md
@@ -36,7 +36,7 @@ the RAM enable flag or the ROM bank number.
 #### When bit 8 is clear
 
 When the least significant bit of the upper address byte is zero, the value that is written controls whether the RAM is enabled.
-When any value with `$A` in the lower 4 bits is written to this address range, RAM is enabled.
+Save RAM will be enabled if and only if the lower 4 bits of the value written here are `$A`.
 If any other value is written, RAM is disabled.
 
 Examples of addresses that can control RAM: $0000–00FF, $0200–02FF, $0400–04FF, ..., $3E00–3EFF.

--- a/src/MBC2.md
+++ b/src/MBC2.md
@@ -36,7 +36,7 @@ the RAM enable flag or the ROM bank number.
 #### When bit 8 is clear
 
 When the least significant bit of the upper address byte is zero, the value that is written controls whether the RAM is enabled.
-When the value written to this address range is equal to `$0A`, RAM is enabled.
+When any value with `$A` in the lower 4 bits is written to this address range, RAM is enabled.
 If any other value is written, RAM is disabled.
 
 Examples of addresses that can control RAM: $0000–00FF, $0200–02FF, $0400–04FF, ..., $3E00–3EFF.


### PR DESCRIPTION
I noticed because my emulator couldn't pass https://github.com/Gekkio/mooneye-test-suite/blob/main/emulator-only/mbc2/bits_ramg.s from the Mooneye test suite. Upon changing `val == 0xa` in my code to `val&0xf == 0xa` it passes the test. I don't own a real Game Boy and haven't even looked into the test assembly so take this with a grain of salt.