### PR TITLE
Add description for out of bounds MBC ram access

### DIFF
--- a/src/MBCs.md
+++ b/src/MBCs.md
@@ -23,7 +23,7 @@ Double Speed Mode.
 
 ## MBC Unmapped RAM Bank Access
 
-On most of the MBC's in case an unmapped RAM bank is selected (which would be translate to an out of bounds RAM address by the MBC controller), 
+In most MBCs, if an unmapped RAM bank is selected (which would be translate to an out of bounds RAM address by the MBC controller), 
 the MBC will simply wrap around the internal ram address and would access a valid RAM address.
 
 The MBC internal address being accessed can be calculated using this formula: `((address - external_ram_start_address) + (active_ram_bank * ram_bank_size)) % max_external_ram_size`.

--- a/src/MBCs.md
+++ b/src/MBCs.md
@@ -25,4 +25,4 @@ Double Speed Mode.
 
 On most of the MBC's in case an out of bounds address is accessed (selecting unmapped RAM bank),
 only the mapped bits from the address will be used.
-The actual address being accessed can be calculated using this formula: `address & (max_ram_size - 1)`.
+The actual address being accessed can be calculated using this formula: `address % max_ram_size`.

--- a/src/MBCs.md
+++ b/src/MBCs.md
@@ -20,3 +20,9 @@ so, it might be nevertheless possible to use Double Speed during periods
 which use only code and data which is located in internal RAM. Despite the 
 above, a self-made MBC1-EPROM card appears to work stable and fine even in 
 Double Speed Mode.
+
+## MBC Out Of Bounds RAM Access
+
+On most of the MBC's in case an out of bounds address is accessed (selecting unmapped RAM bank),
+only the mapped bits from the address will be used.
+The actual address being accessed can be calculated using this formula: `address & (max_ram_size - 1)`.

--- a/src/MBCs.md
+++ b/src/MBCs.md
@@ -21,8 +21,9 @@ which use only code and data which is located in internal RAM. Despite the
 above, a self-made MBC1-EPROM card appears to work stable and fine even in 
 Double Speed Mode.
 
-## MBC Out Of Bounds RAM Access
+## MBC Unmapped RAM Bank Access
 
-On most of the MBC's in case an out of bounds address is accessed (selecting unmapped RAM bank),
-only the mapped bits from the address will be used.
-The actual address being accessed can be calculated using this formula: `address % max_ram_size`.
+On most of the MBC's in case an unmapped RAM bank is selected (which would be translate to an out of bounds RAM address by the MBC controller), 
+the MBC controller will simply wrap around the internal ram address and would access valid RAM address.
+
+The MBC internal address being accessed can be calculated using this formula: `((address - external_ram_start_address) * ram_bank_size) % max_external_ram_size`.

--- a/src/MBCs.md
+++ b/src/MBCs.md
@@ -24,6 +24,6 @@ Double Speed Mode.
 ## MBC Unmapped RAM Bank Access
 
 On most of the MBC's in case an unmapped RAM bank is selected (which would be translate to an out of bounds RAM address by the MBC controller), 
-the MBC controller will simply wrap around the internal ram address and would access valid RAM address.
+the MBC will simply wrap around the internal ram address and would access a valid RAM address.
 
 The MBC internal address being accessed can be calculated using this formula: `((address - external_ram_start_address) + (active_ram_bank * ram_bank_size)) % max_external_ram_size`.

--- a/src/MBCs.md
+++ b/src/MBCs.md
@@ -26,4 +26,4 @@ Double Speed Mode.
 On most of the MBC's in case an unmapped RAM bank is selected (which would be translate to an out of bounds RAM address by the MBC controller), 
 the MBC controller will simply wrap around the internal ram address and would access valid RAM address.
 
-The MBC internal address being accessed can be calculated using this formula: `((address - external_ram_start_address) * ram_bank_size) % max_external_ram_size`.
+The MBC internal address being accessed can be calculated using this formula: `((address - external_ram_start_address) + (active_ram_bank * ram_bank_size)) % max_external_ram_size`.


### PR DESCRIPTION
This is based on:
- Source code of the SameBoy emulator
- Disassembling Pokemon Pinball which depends on this behavior
- Mbc1 schematics - https://www.devrs.com/gb/files/mbc1.gif

Since there are many types of MBC's I added that this is for most of the MBC's