### PR TITLE
Make the priority flag description clearer by explicitly referring to "color IDs" instead of "colors"

### DIFF
--- a/src/Graphics.md
+++ b/src/Graphics.md
@@ -20,10 +20,10 @@ in 8×8 squares, called _tiles_ (or sometimes "patterns" or "characters"), often
 the base unit in Game Boy graphics.
 
 A tile does not encode color information. Instead, a tile assigns a
-_color ID_ to each of its pixels, ranging from 0 to 3. For this reason,
+[_color indices_](<#Data format>) to each of its pixels, ranging from 0 to 3. For this reason,
 Game Boy graphics are also called _2bpp_ (2 bits per pixel). When a tile is used
-in the Background or Window, these color IDs are associated with a _palette_. When
-a tile is used in an object, the IDs 1 to 3 are associated with a palette, but
+in the Background or Window, these [color indices](<#Data format>) are associated with a _palette_. When
+a tile is used in an object, the indices 1 to 3 are associated with a palette, but
 ID 0 means transparent.
 
 ## Palettes

--- a/src/OAM.md
+++ b/src/OAM.md
@@ -53,7 +53,7 @@ tile is "NN & \$FE", and the bottom 8×8 tile is "NN | \$01".
   "Attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 4:"DMG palette" 3:"Bank" 2-0:"CGB palette";
 }}
 
-- **Priority**: `0` = No, `1` = BG and Window [color IDs](./Tile_Data.md) 1–3 are drawn over this OBJ
+- **Priority**: `0` = No, `1` = BG and Window [color indices](<#Data format>) 1–3 are drawn over this OBJ
 - **Y flip**: `0` = Normal, `1` = Entire OBJ is vertically mirrored
 - **X flip**: `0` = Normal, `1` = Entire OBJ is horizontally mirrored
 - **DMG palette** *\[Non CGB Mode only\]*: `0` = OBP0, `1` = OBP1

--- a/src/OAM.md
+++ b/src/OAM.md
@@ -53,7 +53,7 @@ tile is "NN & \$FE", and the bottom 8×8 tile is "NN | \$01".
   "Attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 4:"DMG palette" 3:"Bank" 2-0:"CGB palette";
 }}
 
-- **Priority**: `0` = No, `1` = BG and Window colors 1–3 are drawn over this OBJ
+- **Priority**: `0` = No, `1` = BG and Window [color IDs](./Tile_Data.md) 1–3 are drawn over this OBJ
 - **Y flip**: `0` = Normal, `1` = Entire OBJ is vertically mirrored
 - **X flip**: `0` = Normal, `1` = Entire OBJ is horizontally mirrored
 - **DMG palette** *\[Non CGB Mode only\]*: `0` = OBP0, `1` = OBP1

--- a/src/Palettes.md
+++ b/src/Palettes.md
@@ -5,7 +5,7 @@
 
 ### FF47 — BGP (Non-CGB Mode only): BG palette data
 
-This register assigns gray shades to the [color IDs](./Tile_Data.md) of the BG and Window tiles.
+This register assigns gray shades to the [color indices](<#Data format>) of the BG and Window tiles.
 
 {{#bits 8 >
   "Color for..."  7-6:"ID 3" 5-4:"ID 2" 3-2:"ID 1" 1-0:"ID 0";

--- a/src/Tile_Data.md
+++ b/src/Tile_Data.md
@@ -81,18 +81,18 @@ $38 $7C` appears as follows:
 </figure>
 
 For the first row, the values `$3C $7E` are `00111100` and `01111110` in
-binary. The leftmost bits are 0 and 0, thus the color ID is binary `00`, or 0.
-The next bits are 0 and 1, thus the color ID is binary `10`, or 2 (remember to
+binary. The leftmost bits are 0 and 0, thus the [color index](<#Data format>) is binary `00`, or 0.
+The next bits are 0 and 1, thus the [color index](<#Data format>) is binary `10`, or 2 (remember to
 flip the order of the bits!). The full eight-pixel row evaluates to 0 2 3 3 3 3
 2 0.
 
 A tool for viewing tiles can be found
 [here](https://www.huderlem.com/demos/gameboy2bpp.html).
 
-So, each pixel has a color ID of 0 to 3. The color
+So, each pixel has a [color index](<#Data format>) of 0 to 3. The color
 numbers are translated into real colors (or gray shades) depending on
 the current palettes, except that when the tile is used in an OBJ the
-color ID 0 means transparent. The palettes are defined through registers
+[color index](<#Data format>) 0 means transparent. The palettes are defined through registers
 [BGP](<#FF47 — BGP (Non-CGB Mode only): BG palette data>),
 [OBP0 and OBP1](<#FF48–FF49 — OBP0, OBP1 (Non-CGB Mode only): OBJ palette 0, 1 data>), and
 [BCPS/BGPI](<#FF68 — BCPS/BGPI (CGB Mode only): Background color palette specification / Background palette index>),

--- a/src/Tile_Maps.md
+++ b/src/Tile_Maps.md
@@ -28,7 +28,7 @@ entry in VRAM Bank 0, that is, 1:9800 defines the attributes for the tile at
   "BG attributes"  7:"Priority" 6:"Y flip" 5:"X flip" 3:"Bank" 2-0:"Color palette";
 }}
 
-- **Priority**: `0` = No; `1` = Colors 1–3 of the corresponding BG/Window tile are drawn over OBJ, regardless of [OBJ priority](<#Byte 3 — Attributes/Flags>)
+- **Priority**: `0` = No; `1` = [Color indices](<#Data format>) 1–3 of the corresponding BG/Window tile are drawn over OBJ, regardless of [OBJ priority](<#Byte 3 — Attributes/Flags>)
 - **Y flip**: `0` = Normal; `1` = Tile is drawn vertically mirrored
 - **X flip**: `0` = Normal; `1` = Tile is drawn horizontally mirrored
 - **Bank**: `0` = Fetch tile from VRAM bank 0; `1` = Fetch tile from VRAM bank 1


### PR DESCRIPTION
When reading the description of byte 3 in the OAM section and more precisely, the priority flag, I was confused whether the sentence
"Priority: 0 = No, 1 = BG and Window colors 1–3 are drawn over this OBJ"
was referring to colors, as in actual colors values (0: White, ...) or whether it was referring to color IDs (which might be mapped by the palette to other color values then their ID might suggest). I suppose it refers to color IDs, which is why I would make that more explicit.

If that is wrong I would suggest changing it to make it clear that color IDs are not meant and instead color values. I was not able to find a conclusive source on this.

Note that the link that is used for the [color IDs](https://gbdev.io/pandocs/Tile_Data.html) is the same as used in the [palettes section](https://gbdev.io/pandocs/Palettes.html#ff47--bgp-non-cgb-mode-only-bg-palette-data).
