### PR TITLE
MBC7: Note about HALT and sensor relying on PHI/ cart clock

### DIFF
--- a/src/MBC7.md
+++ b/src/MBC7.md
@@ -42,7 +42,7 @@ value without first erasing it; attempts to do so yield no change.
 
 Once the latch for a sample update has been triggered the CPU should not be
 put into HALT for at least 1.2 µs since HALTing turns off the PHI cartridge
-signal (clock from the GB) which the MBC7 accelerometer sensor relies on.
+signal (the System Clock) which the MBC7 accelerometer sensor relies on.
 If that clock is turned off too soon the X and Y values will have signficantly
 more noise in the sampled data.
 

--- a/src/MBC7.md
+++ b/src/MBC7.md
@@ -40,6 +40,12 @@ registers. Reads return $FF. Other writes do not appear to do anything
 (Partially unconfirmed). Note that you cannot re-latch the accelerometer
 value without first erasing it; attempts to do so yield no change.
 
+Once the latch for a sample update has been triggered the cpu should not be
+put into HALT for at least 1.2 msec since HALTing turns off the PHI cartridge
+signal (clock from the GB) which the MBC7 accelerometer sensor relies on.
+If that clock is turned off too soon the X and Y values will have signficantly
+more noise in the sampled data.
+
 ### Ax2x/Ax3x - Accelerometer X value (Read Only)
 
 Ax2x contains the low byte of the X value (lower values are towards the
@@ -134,5 +140,5 @@ enable section as well (0000-1FFF)
 
 ## External links
 
-- Source: [GBDev Forums thread by endrift](https://web.archive.org/web/20240429225227/http://gbdev.gg8.se/forums/viewtopic.php?id=448)
+- Source: [GBDev Forums thread by endrift](https://web.archive.org/web/20250424080817/https://gbdev.gg8.se/forums/viewtopic.php?id=448)
 

--- a/src/MBC7.md
+++ b/src/MBC7.md
@@ -41,7 +41,7 @@ registers. Reads return $FF. Other writes do not appear to do anything
 value without first erasing it; attempts to do so yield no change.
 
 Once the latch for a sample update has been triggered the CPU should not be
-put into HALT for at least 1.2 msec since HALTing turns off the PHI cartridge
+put into HALT for at least 1.2 µs since HALTing turns off the PHI cartridge
 signal (clock from the GB) which the MBC7 accelerometer sensor relies on.
 If that clock is turned off too soon the X and Y values will have signficantly
 more noise in the sampled data.

--- a/src/MBC7.md
+++ b/src/MBC7.md
@@ -40,7 +40,7 @@ registers. Reads return $FF. Other writes do not appear to do anything
 (Partially unconfirmed). Note that you cannot re-latch the accelerometer
 value without first erasing it; attempts to do so yield no change.
 
-Once the latch for a sample update has been triggered the cpu should not be
+Once the latch for a sample update has been triggered the CPU should not be
 put into HALT for at least 1.2 msec since HALTing turns off the PHI cartridge
 signal (clock from the GB) which the MBC7 accelerometer sensor relies on.
 If that clock is turned off too soon the X and Y values will have signficantly

--- a/src/MBC7.md
+++ b/src/MBC7.md
@@ -43,7 +43,7 @@ value without first erasing it; attempts to do so yield no change.
 Once the latch for a sample update has been triggered the CPU should not be
 put into HALT for at least 1.2 µs since HALTing turns off the PHI cartridge
 signal (the System Clock) which the MBC7 accelerometer sensor relies on.
-If that clock is turned off too soon the X and Y values will have signficantly
+If that clock is turned off too soon the X and Y values will have significantly
 more noise in the sampled data.
 
 ### Ax2x/Ax3x - Accelerometer X value (Read Only)


### PR DESCRIPTION
+ update the link to the forum discussion where I've added a more detailed note + chart of captured data