### PR TITLE
Clarify clock terminology and speed

### DIFF
--- a/src/Audio.md
+++ b/src/Audio.md
@@ -47,7 +47,7 @@ The speaker merges back the two channels, losing the stereo aspect entirely.
 
 The Game Boy's sound chip is called the <abbr title="Audio Processing Unit">APU</abbr>.
 
-The APU runs off the same master clock as the rest of the Game Boy, which is to say, it is fully synced with the CPU and [PPU](<#Rendering overview>).
+The APU runs off the same Master Clock as the rest of the Game Boy, which is to say, it is fully synced with the CPU and [PPU](<#Rendering overview>).
 This also means that the APU runs about 2.4% faster on the SGB1, increasing frequencies by as much and thus sounding slightly higher-pitched.
 The SGB2 rectifies this issue.
 

--- a/src/External_Connectors.md
+++ b/src/External_Connectors.md
@@ -5,7 +5,7 @@
  Pin  | Name   | Explanation
 ------|--------|--------------
   1   | VDD    | Power Supply +5V DC
-  2   | PHI    | System Clock
+  2   | PHI    | System Clock ≅ 1.05 MHz <br> (CGB Double-speed mode: ≅ 2.10 MHz)
   3   | /WR    | Write
   4   | /RD    | Read
   5   | /CS    | Chip Select

--- a/src/External_Connectors.md
+++ b/src/External_Connectors.md
@@ -5,7 +5,7 @@
  Pin  | Name   | Explanation
 ------|--------|--------------
   1   | VDD    | Power Supply +5V DC
-  2   | PHI    | System Clock ≅ 1.05 MHz <br> (CGB Double-speed mode: ≅ 2.10 MHz)
+  2   | PHI    | System Clock ~ 1.05 MHz <br> (CGB Double-speed mode: ~ 2.10 MHz)
   3   | /WR    | Write
   4   | /RD    | Read
   5   | /CS    | Chip Select

--- a/src/Gameboy_Camera.md
+++ b/src/Gameboy_Camera.md
@@ -182,7 +182,7 @@ The reason for that is that the sensor chip sometimes handles the signals on the
 
 :::tip NOTE
 
-Since the PHI signal runs twice as fast in CGB Double-speed mode the values used for exposure time should be doubled.
+Since the PHI signal runs twice as fast in CGB Double-speed mode, the values used for exposure time should be doubled.
 
 :::
 

--- a/src/Gameboy_Camera.md
+++ b/src/Gameboy_Camera.md
@@ -175,14 +175,14 @@ Those registers form a 4×4 matrix with 3 bytes per element. They handle ditheri
 ## Game Boy Camera Timings
 
 The capture process is started when the A000 register of the Game Boy Camera cartridge is written with any value with bit 0 set to "1".
-The Game Boy Camera cartridge is one of the few cartridges that use the PHI signal (clock from the GB).
-That signal is a 1 MiHz clock (1047567 Hz).
-The M6438FP chip needs a clock input too, which is half the frequency of the PHI pin (0.5 Mihz, 524288Hz).
+The Game Boy Camera cartridge is one of the few cartridges that use the PHI cartridge signal (the System Clock).
+That signal is a 1.048576 MHz clock (2.097152 MHz in CGB Double-speed mode).
+The M6438FP chip needs a clock input too, which is half the frequency of the PHI signal.
 The reason for that is that the sensor chip sometimes handles the signals on the rising edge of the clock, but other times on the falling edge.
 
 :::tip NOTE
 
-This means that the GB Camera shouldn't be used in GBC double speed mode!
+Since the PHI signal runs twice as fast in CGB Double-speed mode the values used for exposure time should be doubled.
 
 :::
 

--- a/src/SGB_Functions.md
+++ b/src/SGB_Functions.md
@@ -84,10 +84,10 @@ directly in order to produce other sound effects or music.
 Finally, it is possible to write program code or data into SNES memory,
 and to execute such program code by using the SNES CPU.
 
-## SGB System Clock
+## SGB Clock Speed
 
-Because the SGB is synchronized to the SNES CPU, the Game Boy system
-clock is directly chained to the SNES system clock. In result, the
+Because the SGB is synchronized to the SNES CPU, the Game Boy Master
+Clock is directly chained to the SNES Master Clock. In result, the
 Game Boy CPU, video controller, timers, and sound frequencies will be all
 operated approx 2.4% faster than handheld systems. Basically, this
 should be no problem, and the game will just run a little bit faster.
@@ -99,6 +99,6 @@ hardware. Also, "PAL version" SNES models which use a
 50Hz display refresh rate (rather than 60Hz) result in
 respectively slower Game Boy timings.
 
-- NTSC SGB: 21.477 MHz master clock, 4.2955 MHz GB clock, 2.41% fast
-- PAL SGB: 21.281 MHz master clock, 4.2563 MHz GB clock, 1.48% fast
+- NTSC SGB: 21.477 MHz Master Clock, 4.2955 MHz GB Master Clock, 2.41% fast
+- PAL SGB: 21.281 MHz Master Clock, 4.2563 MHz GB Master Clock, 1.48% fast
 - NTSC SGB2: Separate 20.972 MHz crystal, correct speed

--- a/src/Specifications.md
+++ b/src/Specifications.md
@@ -20,7 +20,10 @@ td:first-child {
       <td>CPU</td><td colspan="4">8-bit 8080-like Sharp CPU (speculated to be a SM83 core)</td>
     </tr>
     <tr>
-      <td>CPU freq</td><td colspan="2">4.194304&nbsp;MHz<sup class="footnote-reference"><a href="#dmg_clk">1</a></sup></td><td>Depends on revision<sup class="footnote-reference"><a href="#sgb_clk">2</a></sup></td><td>Up to 8.388608&nbsp;MHz</td>
+      <td>Master Clock</td><td colspan="2">4.194304&nbsp;MHz<sup class="footnote-reference"><a href="#dmg_clk">1</a></sup></td><td>Depends on revision<sup class="footnote-reference"><a href="#sgb_clk">2</a></sup></td><td>Up to 8.388608&nbsp;MHz</td>
+    </tr>
+    <tr>
+      <td>System Clock</td><td colspan="4">1/4 the frequency of Master Clock</td>
     </tr>
     <tr>
         <td>Work RAM</td><td colspan="3">8&nbsp;KiB</td><td>32&nbsp;KiB<sup class="footnote-reference"><a href="#compat">3</a></sup> (4&nbsp;+&nbsp;7&nbsp;×&nbsp;4&nbsp;KiB)</td>
@@ -62,7 +65,7 @@ td:first-child {
 Real DMG units tend to run about 50-70 PPM slow. Accuracy of other models is unknown. [See this page](https://github.com/jkotlinski/gbchrono) for more details.
 
 [^sgb_clk]:
-SGB1 cartridges derive the GB CPU clock from the SNES' clock, [yielding a clock speed a bit higher](<#SGB System Clock>), which differs slightly between NTSC and PAL systems.
+SGB1 cartridges derive the GB CPU clock from the SNES' clock, [yielding a clock speed a bit higher](<#SGB Clock Speed>), which differs slightly between NTSC and PAL systems.
 SGB2 instead uses a clock internal to the cartridge, and so has the same speed as the handhelds.
 
 [^compat]:


### PR DESCRIPTION
Currently there is some ambiguity about clock terminology and speed. This attempts to differentiate between a System Clock / PHI of ~1MHz and a Master Clock of ~4MHz (2x those in Double-speed mode).

Alternatively "Oscillation Clock" could be used if that's preferable to "Master Clock"

Testing the water with this approach, but open to other ideas