### PR TITLE
mbc7 time units + cgb info

### DIFF
--- a/src/MBC7.md
+++ b/src/MBC7.md
@@ -41,10 +41,11 @@ registers. Reads return $FF. Other writes do not appear to do anything
 value without first erasing it; attempts to do so yield no change.
 
 Once the latch for a sample update has been triggered the CPU should not be
-put into HALT for at least 1.2 microseconds since HALTing turns off the PHI cartridge
+put into HALT for at least 1.2 milliseconds since HALTing turns off the PHI cartridge
 signal (the System Clock) which the MBC7 accelerometer sensor relies on.
 If that clock is turned off too soon the X and Y values will have significantly
-more noise in the sampled data.
+more noise in the sampled data. The 1.2 milliseconds duration is the same
+regardless of whether or not the CPU is in CGB Double-speed mode.
 
 ### Ax2x/Ax3x - Accelerometer X value (Read Only)
 


### PR DESCRIPTION
The time units for the MBC7 settling time got fixed to incorrect units, this changes them from "microseconds" to the correct "milliseconds".

It also adds information about what happens in CGB Double-speed mode based on some testing today (the duration remains unchanged).