### PR TITLE
Removed speculation MBC4 was skipped due to "superstition"

### DIFF
--- a/src/MBC5.md
+++ b/src/MBC5.md
@@ -2,10 +2,8 @@
 
 It can map up to 64 Mbits (8 MiB) of ROM.
 
-MBC5 (Memory Bank Controller 5) is the 4th generation MBC. There
-apparently was no MBC4, presumably because of the superstition about the
-number 4 in Japanese culture. It is the first MBC that is guaranteed to
-work properly with GBC Double Speed mode.
+MBC5 (Memory Bank Controller 5) is the 5th generation MBC. (The MBC4 was not used in any released cartridges.)
+It is the first MBC that is guaranteed to work properly with GBC Double Speed mode.
 
 ## Memory
 


### PR DESCRIPTION
Removed speculation that the MBC4 chip number was skipped intentionally.
This has seemingly been debunked, and was very unlikely to begin with.
