### PR TITLE
Four player adapter edits

### DIFF
--- a/src/Four_Player_Adapter.md
+++ b/src/Four_Player_Adapter.md
@@ -159,7 +159,7 @@ The upper-half of STAT1, STAT2, and STAT3 are updated based on the ping response
 to show when Game Boys are "connected". If for whatever reason, the ping responses
 are not sent, the status bits are unset.
 
-Some examples of ping packets sent byte the DMG-07 are shown below:
+Some examples of ping packets sent by the DMG-07 are shown below:
 
 Packet        | Description
 --------------|-------------------------------------------------------


### PR DESCRIPTION
On the rendered pandocs site some of the Four Player Adapter page tables appear broken (showing up as markdown source). I think because they are missing blank lines above the tables. This attempts to fix that.

Plus fixing a small typo.