### PR TITLE
Specified the status of the VRAM DMA register once a transfer is done.

### DIFF
--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -127,7 +127,7 @@ This allows for a transfer of 2280 bytes during VBlank, which is up to 142.5 til
 #### Status of the registers after the end of the transfer
 
 The source and destination address regisers are both incremented by $10 bytes for each block of $10 bytes transfered after the transfer is done.
-FF55 is set to $FF once the transfer ends.
+FF55 is always equal to $FF once the transfer ends
 
 ### VRAM Banks
 

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -124,6 +124,11 @@ Speed Mode).
 
 This allows for a transfer of 2280 bytes during VBlank, which is up to 142.5 tiles.
 
+#### Status of the registers after the end of the transfer
+
+The source and destination address are both incremented by $10 bytes for each block of $10 bytes transfered after the transfer is done.
+FF55 is set to $FF once the transfer ends.
+
 ### VRAM Banks
 
 The CGB has twice the VRAM of the DMG, but it is banked and either bank

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -39,14 +39,33 @@ tested on Echo RAM, OAM, FEXX, IO and HRAM\]. Trying to specify a source
 address in VRAM will cause garbage to be copied.
 
 The four lower bits of this address will be ignored and treated as 0.
-The address specified by those registers is cached internally and incremented by $10 for each block of $10 bytes successfully transferred. The cached address persists until the registers are written again.
+After a transfer the address contained in this register pair is 
+by $10 for each block of $10 bytes transfered, these 
+registers being write-only, this can only be observed by doing another 
+transfer without updating these registers.
+
 
 #### FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]
 
 These two registers specify the address within 8000-9FF0 to which the
 data will be copied. Only bits 12-4 are respected; others are ignored.
 The four lower bits of this address will be ignored and treated as 0.
-The address specified by those registers is cached internally and incremented by $10 for each block of $10 bytes successfully transferred. The cached address persists until the registers are written again.
+
+#### State of the VRAM DMA source/destination registers after a transfer
+
+After a transfer, the source/destination registers are incremented by $10 
+for each block of $10 bytes transfered.
+Despite both the VRAM DMA source/destination registers being write-only,
+knowing their state after a transfer can turn useful when performing
+multiple transfer in a row.
+For instance, a transfer of one large block is mostly equivalent to
+multiple transfers of smaller blocks, without needing to update the source
+nor the destination registers between each of the smaller transfers.
+Another use case would be to fill VRAM with the same $10 bytes block repeated 
+all over, as only the source address register would need be updated after each
+transfer, the destination register being automatically incremented by
+the block size after each transfer.
+
 
 #### FF55 — HDMA5 (CGB Mode only): VRAM DMA length/mode/start
 

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -39,12 +39,14 @@ tested on Echo RAM, OAM, FEXX, IO and HRAM\]. Trying to specify a source
 address in VRAM will cause garbage to be copied.
 
 The four lower bits of this address will be ignored and treated as 0.
+The address specified by those registers is incremented by $10 for each block of $10 bytes transfered successfully.
 
 #### FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]
 
 These two registers specify the address within 8000-9FF0 to which the
 data will be copied. Only bits 12-4 are respected; others are ignored.
 The four lower bits of this address will be ignored and treated as 0.
+The address specified by those registers is incremented by $10 for each block of $10 bytes transfered successfully.
 
 #### FF55 — HDMA5 (CGB Mode only): VRAM DMA length/mode/start
 
@@ -123,11 +125,6 @@ transferred per microsecond (even if the itself program runs it Normal
 Speed Mode).
 
 This allows for a transfer of 2280 bytes during VBlank, which is up to 142.5 tiles.
-
-#### Status of the registers after the end of the transfer
-
-The source and destination address regisers are both incremented by $10 bytes for each block of $10 bytes transfered after the transfer is done.
-FF55 is always equal to $FF once the transfer ends
 
 ### VRAM Banks
 

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -39,14 +39,14 @@ tested on Echo RAM, OAM, FEXX, IO and HRAM\]. Trying to specify a source
 address in VRAM will cause garbage to be copied.
 
 The four lower bits of this address will be ignored and treated as 0.
-The address specified by those registers is incremented by $10 for each block of $10 bytes transfered successfully.
+The address specified by those registers is cached internally and incremented by $10 for each block of $10 bytes successfully transferred. The cached address persists until the registers are written again.
 
 #### FF53–FF54 — HDMA3, HDMA4 (CGB Mode only): VRAM DMA destination (high, low) \[write-only\]
 
 These two registers specify the address within 8000-9FF0 to which the
 data will be copied. Only bits 12-4 are respected; others are ignored.
 The four lower bits of this address will be ignored and treated as 0.
-The address specified by those registers is incremented by $10 for each block of $10 bytes transfered successfully.
+The address specified by those registers is cached internally and incremented by $10 for each block of $10 bytes successfully transferred. The cached address persists until the registers are written again.
 
 #### FF55 — HDMA5 (CGB Mode only): VRAM DMA length/mode/start
 

--- a/src/CGB_Registers.md
+++ b/src/CGB_Registers.md
@@ -126,7 +126,7 @@ This allows for a transfer of 2280 bytes during VBlank, which is up to 142.5 til
 
 #### Status of the registers after the end of the transfer
 
-The source and destination address are both incremented by $10 bytes for each block of $10 bytes transfered after the transfer is done.
+The source and destination address regisers are both incremented by $10 bytes for each block of $10 bytes transfered after the transfer is done.
 FF55 is set to $FF once the transfer ends.
 
 ### VRAM Banks


### PR DESCRIPTION
I specified what the content of the VRAM DMA registers are once a transfer is done.

"The source and destination address regisers are both incremented by $10 bytes for each block of $10 bytes transfered after the transfer is done.
FF55 is always equal to $FF once the transfer ends."

It is useful information when multiple VRAM DMA transfer need to be performed in a row.
For example if one wants to fill VRAM with only 0 using one array of 16 null bytes as the source, as the destination address registers don't need to be updated after each transfer, but the source address registers always need to be reset back to the address of the begining of the source array after each transfer
Here is some assembly code that takes advantage of this in order to clear one bank of VRAM
_zero_x16 is an array of 16 null bytes, aligned on a 16 bytes boundary
[clear_vram.s](https://github.com/user-attachments/files/22323433/clear_vram.txt)
