### PR TITLE
Point the boot ROM disassembly links to its new home

### DIFF
--- a/src/Power_Up_Sequence.md
+++ b/src/Power_Up_Sequence.md
@@ -19,7 +19,7 @@ CGB  | 256 + 1792   | Split in two parts, with the cartridge header in the middl
 AGB0 | 256 + 1792   | Increments B register for GBA identification
 AGB  | 256 + 1792   | Fixes ["logo TOCTTOU"](<#Bypass>)
 
-[A disassembly of all of them is available online.](https://github.com/ISSOtm/gb-bootroms)
+[A disassembly of all of them is available online.](https://codeberg.org/ISSOtm/gb-bootroms)
 
 ## Monochrome models (DMG0, DMG, MGB)
 
@@ -121,13 +121,13 @@ The boot ROM picks a compatibility palette using an ID computed using the follow
    * If this check fails, palettes ID $00 is used.
    * Otherwise, the algorithm proceeds.
 1. Compute the sum of all 16 [game title](<#0134-0143 — Title>) bytes, storing this as the "title checksum".
-1. Find the title checksum [in a table](https://github.com/ISSOtm/gb-bootroms/blob/443d7f057ae06e8d1d76fa8083650cf0be2cd0ae/src/cgb.asm#L1221-L1230), and record its index within the table.
+1. Find the title checksum [in a table](https://codeberg.org/ISSOtm/gb-bootroms/src/commit/443d7f057ae06e8d1d76fa8083650cf0be2cd0ae/src/cgb.asm#L1221-L1230), and record its index within the table.
 
    An almost-complete list of titles corresponding to the different checksums can be found in [Liji's free CGB boot ROM reimplementation](https://github.com/LIJI32/SameBoy/blob/1d7692cff5552e296be5e1ab075c4f187f57132c/BootROMs/cgb_boot.asm#L230-L328).
    * If not found, palettes ID $00 is used.
    * If the index is 64 or below, the index is used as-is as the palettes ID, and the algorithm ends.
    * Otherwise, it must be further corrected based on the title's fourth letter; proceed to the step below.
-1. The fourth letter is searched for in [another table](https://github.com/ISSOtm/gb-bootroms/blob/443d7f057ae06e8d1d76fa8083650cf0be2cd0ae/src/cgb.asm#L1232-L1240).
+1. The fourth letter is searched for in [another table](https://codeberg.org/ISSOtm/gb-bootroms/src/commit/443d7f057ae06e8d1d76fa8083650cf0be2cd0ae/src/cgb.asm#L1232-L1240).
    * If the letter can't be found, palettes ID $00 is used.
    * If the letter is found, the index obtained in the previous step is increased by 14 times the row index to get the palettes ID.
      (So, if the letter was found in the first row, the index is unchanged; if it's found in the second row, it's increased by 14, and so on.)
@@ -265,7 +265,7 @@ As indicated by the "+ 1" in the "AGB (DMG mode)" column, if on AGB, that value 
 
 <!-- How else do I prevent the footnote definition from being too greedy? >_< -->
 
-The tables above were obtained from analysis of [the boot ROM's disassemblies](https://github.com/ISSOtm/gb-bootroms), and confirmed using Mooneye-GB tests [`acceptance/boot_regs-dmg0`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-dmg0.s), [`acceptance/boot_regs-dmgABC`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-dmgABC.s), [`acceptance/boot_regs-mgb`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-mgb.s), [`acceptance/boot_regs-sgb`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-sgb.s), [`acceptance/boot_regs-sgb2`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-sgb2.s), [`misc/boot_regs-cgb`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/misc/boot_regs-cgb.s), and [`misc/boot_regs-A`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/misc/boot_regs-A.s), plus some extra testing.
+The tables above were obtained from analysis of [the boot ROM's disassemblies](https://codeberg.org/ISSOtm/gb-bootroms), and confirmed using Mooneye-GB tests [`acceptance/boot_regs-dmg0`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-dmg0.s), [`acceptance/boot_regs-dmgABC`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-dmgABC.s), [`acceptance/boot_regs-mgb`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-mgb.s), [`acceptance/boot_regs-sgb`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-sgb.s), [`acceptance/boot_regs-sgb2`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/acceptance/boot_regs-sgb2.s), [`misc/boot_regs-cgb`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/misc/boot_regs-cgb.s), and [`misc/boot_regs-A`](https://github.com/Gekkio/mooneye-gb/blob/ca7ff30b52fd3de4f1527397f27a729ffd848dfa/tests/misc/boot_regs-A.s), plus some extra testing.
 
 ## Hardware registers
 

--- a/src/The_Cartridge_Header.md
+++ b/src/The_Cartridge_Header.md
@@ -19,7 +19,7 @@ CE ED 66 66 CC 0D 00 0B 03 73 00 83 00 0C 00 0D
 BB BB 67 63 6E 0E EC CC DD DC 99 9F BB B9 33 3E
 ```
 
-The way the pixels are encoded is as follows: ([more visual aid](https://github.com/ISSOtm/gb-bootroms/blob/2dce25910043ce2ad1d1d3691436f2c7aabbda00/src/dmg.asm#L259-L269))
+The way the pixels are encoded is as follows: ([more visual aid](https://codeberg.org/ISSOtm/gb-bootroms/src/commit/2dce25910043ce2ad1d1d3691436f2c7aabbda00/src/dmg.asm#L259-L269))
 
 - The bytes `$0104`—`$011B` encode the top half of the logo while the bytes `$011C`–`$0133` encode the bottom half.
 - For each half, each nibble encodes 4 pixels (the MSB corresponds to the leftmost pixel, the LSB to the rightmost); a pixel is lit if the corresponding bit is set.


### PR DESCRIPTION
I've decided to move my code off of GitHub; the permalinks still work (I didn't purge history), but it's preferable if the new location was linked to.