### PR TITLE
Document NR43 values freezing the channel

### DIFF
--- a/src/Audio_Registers.md
+++ b/src/Audio_Registers.md
@@ -402,7 +402,7 @@ This register allows controlling the way the amplitude is randomly switched.
 - **Clock divider**: See the frequency formula below.
   Note that <var>divider</var> = 0 is treated as <var>divider</var> = 0.5 instead.
 
-The frequency at which the LFSR is clocked is <math><mfrac><mn>262144</mn><mrow><mi>divider</mi><mo>×</mo><msup><mn>2</mn><mi>shift</mi></msup></mrow></mfrac></math> Hz.
+The frequency at which the LFSR is clocked is <math><mfrac><mn>262144</mn><mrow><mi>divider</mi><mo>×</mo><msup><mn>2</mn><mi>shift</mi></msup></mrow></mfrac></math> Hz, except that <var>shift</var> being equal to 14 or 15 stops the channel from being clocked entirely.
 
 If the bit shifted out is a 0, the channel emits a 0; otherwise, it emits the volume selected in `NR42`.
 


### PR DESCRIPTION
Turns out `EVER` and `ETOV` are not connected to `ETYR` (https://github.com/furrtek/DMG-CPU-Inside/blob/master/Schematics/20_CHANNEL4.png) which means that 14 and 15 don't select any clock source at all, freezing the channel.