### PR TITLE
Note OBJ_TRN and TEST_EN do not work on any SGB retail unit

### DIFF
--- a/src/SGB_Command_Border.md
+++ b/src/SGB_Command_Border.md
@@ -101,6 +101,8 @@ Thus a border can use three 15-color palettes.
 
 ## SGB Command $18 — OBJ_TRN
 
+This command does nothing on all retail SGB revisions. The following description only applies to some prototype units.
+
 Used to start transferring object attributes to SNES object attribute memory (OAM). Unlike all other
 functions with names ending in "\_TRN", this function does not use the usual
 one-time 4 KiB VRAM transfer method. Instead, when enabled (below
@@ -110,8 +112,6 @@ display, the lower line is masked, and only the upper 20×17 characters
 of the Game Boy screen are used - the masking method is unknown - frozen,
 black, or recommended to be covered by the SGB border, or else ??? Also,
 when the function is enabled, attract mode (built-in borders' screen saver on idle) is not performed.
-
-This command does nothing on some SGB revisions. (SGBv2, SGB2?)
 
 ```
  Byte  Content

--- a/src/SGB_Command_System.md
+++ b/src/SGB_Command_System.md
@@ -51,11 +51,10 @@ Attraction Disable disables this animation.
 
 ## SGB Command $0D — TEST_EN
 
+This command does nothing on all retail SGB revisions. The following description only applies to some prototype units.
+
 Used to enable/disable test mode for "SGB-CPU variable clock speed
 function". This function is disabled by default.
-
-This command does nothing on some SGB revisions. (SGBv2 confirmed,
-unknown on others)
 
 ```
  Byte  Content


### PR DESCRIPTION
This is easily confirmed with disassembly (the OBJ_TRN and TEST_EN handlers are an immediate rts on all retail SGB revisions). Some (but not all) beta SGB BIOS revisions appear to not have this rts and thus appear to have these commands functional.