### PR TITLE
Add MBC30 mapper

### DIFF
--- a/src/MBC3.md
+++ b/src/MBC3.md
@@ -92,3 +92,12 @@ Year-10000-Proof, provided that the cartridge gets used at least every
 
 When accessing the RTC Registers, it is recommended to wait 4 µs
 (4 M-cycles in Normal Speed Mode) between any separate accesses.
+
+
+# MBC30
+
+(4 MiB ROM, 64 KiB RAM, timer)
+
+The MBC30 is practically identical to MBC3 in operation, but is capable of addressing twice as much memory for both ROM and RAM.
+The only title to be shipped with the MBC30 mapper was _Pocket Monsters: Crystal Version_ in Japan, with the various worldwide versions using MBC3.
+


### PR DESCRIPTION
This adds a section to the MBC3 page describing the MBC30 mapper, thus resolves #512.

On balance I think MBC30 is different enough to warrant some isolation -- avoiding complicating the MBC3 documentation -- and similar enough to piggyback on the MBC3 page.

// I started working on this when #637 got closed (which is now open again). I'm making this PR now just because that's what I was heading towards doing, but I'm happy to adapt this or whatever really!