### PR TITLE
Give the Super Game Boy its own ToC chapter

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,20 +37,23 @@
   - [HALT](./halt.md)
 - [CGB Registers](./CGB_Registers.md)
 - [Infrared Communication](./IR.md)
-- [SGB Functions](./SGB_Functions.md)
-  - [Unlocking and Detecting SGB Functions](./SGB_Unlocking.md)
-  - [Command Packet Transfers](./SGB_Command_Packet.md)
-  - [VRAM Transfers](./SGB_VRAM_Transfer.md)
-  - [Color Palettes Overview](./SGB_Color_Palettes.md)
-  - [Command Summary](./SGB_Command_Summary.md)
-    - [Palette Commands](./SGB_Command_Palettes.md)
-    - [Color Attribute Commands](./SGB_Command_Attribute.md)
-    - [Sound Functions](./SGB_Command_Sound.md)
-    - [System Control Commands](./SGB_Command_System.md)
-    - [Multiplayer Command](./SGB_Command_Multiplayer.md)
-    - [Border and OBJ Commands](./SGB_Command_Border.md)
-    - [Removed SGB commands](./SGB_Command_Prototype.md)
-    - [Undocumented SGB commands](./SGB_Command_Undocumented.md)
+
+# Super Game Boy
+
+- [Summary](./SGB_Functions.md)
+- [Unlocking and Detecting SGB Functions](./SGB_Unlocking.md)
+- [Command Packet Transfers](./SGB_Command_Packet.md)
+- [VRAM Transfers](./SGB_VRAM_Transfer.md)
+- [Color Palettes Overview](./SGB_Color_Palettes.md)
+- [Command Summary](./SGB_Command_Summary.md)
+  - [Palette Commands](./SGB_Command_Palettes.md)
+  - [Color Attribute Commands](./SGB_Command_Attribute.md)
+  - [Sound Functions](./SGB_Command_Sound.md)
+  - [System Control Commands](./SGB_Command_System.md)
+  - [Multiplayer Command](./SGB_Command_Multiplayer.md)
+  - [Border and OBJ Commands](./SGB_Command_Border.md)
+  - [Removed SGB commands](./SGB_Command_Prototype.md)
+  - [Undocumented SGB commands](./SGB_Command_Undocumented.md)
 
 # CPU Specifications
 


### PR DESCRIPTION
Those pages hardly involve the MMIO, so it seems more appropriate to move those elsewhere; and, frankly, considering how many pages are in there, a new chapter seems warranted.