### PR TITLE
Re-enable heading navigation in sidebar

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -37,7 +37,6 @@ fold = { enable = true, level = 0 }
 git-repository-url = "https://github.com/gbdev/pandocs"
 edit-url-template = "https://github.com/gbdev/pandocs/edit/master/{path}"
 site-url = "/pandocs/"
-sidebar-header-nav = false
 
 [output.linkcheck2]
 follow-web-links = false


### PR DESCRIPTION
This reverts commit e196504a8e467da45be1eb1aaf364958e45b890e, as I don't see why it was disabled in the first place.